### PR TITLE
[v2.1.5] Fix Various Runtime Crashes

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 06/01/2023
+Date: 06/05/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.1.4"
+    VERSION = "2.1.5"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogServerStatus"

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,7 +1,7 @@
 """bot.py
 
 A subclass of `discord.Bot` that adds ease-of-use instance variables and functions (e.g. database object).
-Date: 05/31/2023
+Date: 06/05/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -15,21 +15,38 @@ from discord.ext import commands
 from simplemysql import SimpleMysql
 
 
-def get_config():
-    """Loads config file and returns JSON data"""
-    # Load configuration file
-    with open('config.cfg') as file:
-        # Load the JSON data
-        _data = json.load(file)
-    return _data
-
-
 class BackstabBot(discord.Bot):
+    @staticmethod
+    def get_datetime_str() -> str:
+        """Return a formatted datetime string for logging"""
+        _now = datetime.now()
+        return _now.strftime("%m/%d/%Y %H:%M:%S")
+    
+    @staticmethod
+    def escape_discord_formatting(text: str) -> str:
+        """Return a string that escapes any of Discord's formatting special characters for the given string"""
+        formatting_chars = ['*', '_', '`', '~', '|']
+        escaped_chars = ['\\*', '\\_', '\\`', '\\~', '\\|']
+        for char, escaped_char in zip(formatting_chars, escaped_chars):
+            text = text.replace(char, escaped_char)
+        return text
+    
+    @staticmethod
+    def get_config() -> dict:
+        """Loads config file and returns JSON data"""
+        # Load configuration file
+        with open('config.cfg') as file:
+            # Load the JSON data
+            _data = json.load(file)
+        return _data
+    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.config = get_config()
+        self.config = BackstabBot.get_config()
         # Database Initialization
         try:
+            print(f"{BackstabBot.get_datetime_str()}: [Startup] Logging into MySQL database... ", end='')
             self.db = SimpleMysql(
                 host=self.config['MySQL']['Host'],
                 port=self.config['MySQL']['Port'],
@@ -39,6 +56,7 @@ class BackstabBot(discord.Bot):
                 autocommit=True,
                 keep_alive=True
             )
+            print("Done.")
         except Exception as e:
             print(f"ERROR: {e}")
             sys.exit(3)
@@ -67,20 +85,6 @@ class BackstabBot(discord.Bot):
         else:
             raise error
     
-    def get_datetime_str(self) -> str:
-        """Return a formatted datetime string for logging"""
-        _now = datetime.now()
-        return _now.strftime("%m/%d/%Y %H:%M:%S")
-    
     def reload_config(self):
         """Reloads config from file and reassigns its data to the bot"""
-        self.config = get_config()
-    
-    def escape_discord_formatting(self, text: str) -> str:
-        formatting_chars = ['*', '_', '`', '~', '|']
-        escaped_chars = ['\\*', '\\_', '\\`', '\\~', '\\|']
-        
-        for char, escaped_char in zip(formatting_chars, escaped_chars):
-            text = text.replace(char, escaped_char)
-        
-        return text
+        self.config = BackstabBot.get_config()


### PR DESCRIPTION
- Refactored bot subclass to be more organized/proper with static methods.
- Refactored ServerStatus cog to have more explicit typing in functions.
- Removed `set_top_player` function and moved its functionality to the `record_player_stats` function.
- Added `PlayerStatsTextChannelID` to config check routine.
- Removed setting stats channel description in the `on_ready` function because it was causing issues if Bot got disconnected from Discord. It was set anyways during the loop.
- `StatusLoop` now checks for "real" games that have 2 or more players before recording stats. This also fixes the top player runtime crash.
- Added top player and end-game time to stats saved message.