### PR TITLE
[v2.1.6] Adds Manual Server Status Option

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.1.5"
+    VERSION = "2.1.6"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogServerStatus"


### PR DESCRIPTION
- Adds `/stats setstatus` slash command for admins to manually set global server status (or set to automatic).
- Fixes "stats saved" dialog printing un-escaped player names.