### PR TITLE
[v2.2.0] Major Refactor & Stats Recording Fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,8 @@
-# These are some examples of commonly ignored file patterns.
-# You should customize this list as applicable to your project.
-# Learn more about .gitignore:
-#     https://www.atlassian.com/git/tutorials/saving-changes/gitignore
-
 # Local config file
 config.cfg
 
-# Local music files
-audio/*
-!audio/*.txt
+# Local dev files
+TODO.txt
 
 # Python compiled bytecode and cache
 **/__pycache__/

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,0 +1,444 @@
+"""CogPlayerStats.py
+
+Handles tasks related to checking player stats and info.
+Date: 06/11/2023
+Authors: David Wolfe (Red-Thirten)
+Licensed under GNU GPLv3 - See LICENSE for more details.
+"""
+
+from datetime import datetime
+
+import discord
+from discord.ext import commands, tasks
+from discord.ext.pages import Paginator, Page
+import common.CommonStrings as CS
+
+
+DEL_STATS_SAVED_MSG_SEC = 60
+
+
+async def get_player_nicknames(ctx: discord.AutocompleteContext):
+    """Autocomplete Context: Get player nicknames
+    
+    Returns array of all player nicknames in the bot's database.
+    """
+    _dbEntries = ctx.bot.db.getAll(
+        "player_stats", 
+        ["nickname"]
+    )
+    if _dbEntries:
+        return [player['nickname'] for player in _dbEntries]
+    else:
+        return []
+
+
+class CogPlayerStats(discord.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.game_over_ids = []
+        #self.bot.db.query("DROP TABLE player_stats") # DEBUGGING
+        self.bot.db.query(
+            "CREATE TABLE IF NOT EXISTS player_stats ("
+                "id INT AUTO_INCREMENT PRIMARY KEY, "
+                "nickname TINYTEXT NOT NULL, "
+                "first_seen DATE NOT NULL, "
+                "score INT NOT NULL, "
+                "deaths INT NOT NULL, "
+                "us_games INT NOT NULL, "
+                "ch_games INT NOT NULL, "
+                "ac_games INT NOT NULL, "
+                "eu_games INT NOT NULL, "
+                "cq_games INT NOT NULL, "
+                "cf_games INT NOT NULL, "
+                "wins INT NOT NULL, "
+                "losses INT NOT NULL, "
+                "top_player INT NOT NULL"
+            ")"
+        )
+    
+    def split_list(self, lst: list, chunk_size: int) -> list[list]:
+        """Split a list into smaller lists of equal size"""
+        if chunk_size <= 0:
+            return [lst]
+        else:
+            num_chunks = len(lst) // chunk_size
+            remainder = len(lst) % chunk_size
+            result = [lst[i*chunk_size:(i+1)*chunk_size] for i in range(num_chunks)]
+            if remainder:
+                result.append(lst[-remainder:])
+            return result
+    
+    def time_to_sec(self, time: str) -> int:
+        """Turns a time string into seconds as an integer"""
+        hours, minutes, seconds = time.split(':')
+        return int(hours) * 3600 + int(minutes) * 60 + int(seconds)
+    
+    async def record_player_stats(self, server_data: dict) -> str:
+        """Record Player Statistics
+        
+        Additively records player statistics to the database given a server's JSON data.
+        New records are created for first-seen players.
+        Returns nickname string of the top player.
+        """
+        print(f"Recording round stats... ", end='')
+
+        # Sanitize input (because I'm paranoid)
+        if server_data == None or len(server_data['players']) < 2:
+            return None
+        
+        # Calculate top player
+        _top_player = None
+        for _p in server_data['players']:
+            if (_top_player == None
+                or _p['score'] > _top_player['score']
+                or (_p['score'] == _top_player['score'] and _p['deaths'] < _top_player['deaths'])):
+                _top_player = _p
+        _top_player = _top_player['name']
+
+        # Calculate and record stats for each player in game
+        for _p in server_data['players']:
+            _dbEntry = self.bot.db.getOne(
+                "player_stats", 
+                [
+                    "id",
+                    "score",
+                    "deaths",
+                    "us_games",
+                    "ch_games",
+                    "ac_games",
+                    "eu_games",
+                    "cq_games",
+                    "cf_games",
+                    "wins",
+                    "losses",
+                    "top_player"
+                ], 
+                ("nickname=%s", [_p['name']])
+            )
+            
+            # Sum round stats with existing player stats
+            if _dbEntry == None:
+                _summed_stats = {
+                    "score": 0,
+                    "deaths": 0,
+                    "us_games": 0,
+                    "ch_games": 0,
+                    "ac_games": 0,
+                    "eu_games": 0,
+                    "cq_games": 0,
+                    "cf_games": 0,
+                    "wins": 0,
+                    "losses": 0,
+                    "top_player": 0
+                }
+            else:
+                _summed_stats = _dbEntry.copy()
+            # Add scores and deaths
+            _summed_stats['score'] += _p['score']
+            _summed_stats['deaths'] += _p['deaths']
+            # Detect player's team and if that team won or lost (draws are omitted)
+            if _p['team'] == 0:
+                _team = server_data['team1_country']
+                if server_data['team1_score'] > server_data['team2_score']:
+                    _summed_stats['wins'] += 1
+                elif server_data['team1_score'] < server_data['team2_score']:
+                    _summed_stats['losses'] += 1
+            else:
+                _team = server_data['team2_country']
+                if server_data['team1_score'] < server_data['team2_score']:
+                    _summed_stats['wins'] += 1
+                elif server_data['team1_score'] > server_data['team2_score']:
+                    _summed_stats['losses'] += 1
+            # Add team they played for
+            if _team == "US":
+                _summed_stats['us_games'] += 1
+            elif _team == "CH":
+                _summed_stats['ch_games'] += 1
+            elif _team == "AC":
+                _summed_stats['ac_games'] += 1
+            else:
+                _summed_stats['eu_games'] += 1
+            # Add gamemode they played
+            if server_data['game_type'] == "capturetheflag":
+                _summed_stats['cf_games'] += 1
+            else:
+                _summed_stats['cq_games'] += 1
+            # Add if they were the top player
+            if _p['name'] == _top_player:
+                _summed_stats['top_player'] += 1
+            
+            # Update player
+            if _dbEntry != None:
+                self.bot.db.update("player_stats", _summed_stats, [f"id={_dbEntry['id']}"])
+            # Insert new player
+            else:
+                _summed_stats['nickname'] = _p['name']
+                _summed_stats['first_seen'] = datetime.now().date()
+                self.bot.db.insert("player_stats", _summed_stats)
+        
+        print("Done.")
+        return _top_player
+    
+    def get_paginator_for_stat(self, stat: str) -> Paginator:
+        """Returns a Leaderboard style Paginator for a given database stat"""
+        _rank = 1
+        _pages = []
+        _dbEntries = self.bot.db.getAll("player_stats", ["nickname", stat], None, [stat, "DESC"], [0, 50]) # Limit to top 50 players
+        if _dbEntries:
+            _dbEntries = self.split_list(_dbEntries, 10) # Split into pages of 10 entries each
+            for _page in _dbEntries:
+                _embed = discord.Embed(
+                    title=f":first_place:  BF2:MC Online | Top {stat.capitalize()} Leaderboard  :first_place:",
+                    description=f"*Top 50 players across all servers.*",
+                    color=discord.Colour.gold()
+                )
+                _nicknames = "```\n"
+                _stats = "```\n"
+                for _e in _page:
+                    _rank_str = f"#{_rank}"
+                    _nicknames += f"{_rank_str.ljust(3)} | {_e['nickname']}\n"
+                    if stat == 'score':
+                        _stats += f"{str(_e[stat]).rjust(5)} pts.\n"
+                    elif stat == 'wins':
+                        _stats += f" {self.bot.infl.no('game', _e[stat])} won\n"
+                    else:
+                        _stats += "\n"
+                    _rank += 1
+                _nicknames += "```"
+                _stats += "```"
+                _embed.add_field(name="Player:", value=_nicknames, inline=True)
+                _embed.add_field(name=f"{stat.capitalize()}:", value=_stats, inline=True)
+                _embed.set_footer(text=f"Unofficial data* -- {self.bot.config['API']['RootURL']}")
+                _pages.append(Page(embeds=[_embed]))
+        else:
+            _embed = discord.Embed(
+                title=f":first_place:  BF2:MC Online | Top {stat.capitalize()} Leaderboard*  :first_place:",
+                description="No stats yet.",
+                color=discord.Colour.gold()
+            )
+            _pages = [Page(embeds=[_embed])]
+        return Paginator(pages=_pages, author_check=False)
+
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        """Listener: On Cog Ready
+        
+        Runs when the cog is successfully cached within the Discord API.
+        """
+        print(f"{self.bot.get_datetime_str()}: [PlayerStats] Successfully cached!")
+        
+        # Check that all channels in the config are valid
+        _cfg_sub_keys = [
+            'PlayerStatsTextChannelID'
+        ]
+        await self.bot.check_channel_ids_for_cfg_key('PlayerStats', _cfg_sub_keys)
+        
+        # Start Status Loop
+        if not self.StatsLoop.is_running():
+            _config_interval = self.bot.config['PlayerStats']['QueryIntervalSeconds']
+            self.StatsLoop.change_interval(seconds=_config_interval)
+            self.StatsLoop.start()
+            print(f"{self.bot.get_datetime_str()}: [PlayerStats] StatsLoop started ({_config_interval} sec. interval).")
+    
+
+    @tasks.loop(seconds=10)
+    async def StatsLoop(self):
+        """Task Loop: Stats Loop
+        
+        Runs every interval period, queries API for new data, 
+        and records player data for any server that has finished a round.
+        """
+        ## Query API for new data
+        await self.bot.query_api()
+
+        ## Check each server if game over -> record stats
+        # Only check if old data exists (so we can compare), and current data exists (avoid errors)
+        if self.bot.old_query_data != None and self.bot.cur_query_data != None:
+            # For all existing servers...
+            for _s_o in self.bot.old_query_data['results']:
+                _server_found = False
+                # Search all current data for matching server
+                for _s_n in self.bot.cur_query_data['results']:
+                    if _s_o['id'] == _s_n['id']:
+                        _server_found = True
+                        # Record old data if current time is equal to old time (indicating a game finished),
+                        # this is the first detection (times will equal until next game),
+                        # and the server isn't empty.
+                        _old_time = self.time_to_sec(_s_o['time_elapsed'])
+                        _new_time = self.time_to_sec(_s_n['time_elapsed'])
+                        if (_old_time == _new_time 
+                            and _s_o['id'] not in self.game_over_ids
+                            and len(_s_n['players']) > 1):
+                            print(f"{self.bot.get_datetime_str()}: [PlayerStats] A server has finished a game:")
+                            print(f"Server     : {_s_o['server_name']}")
+                            print(f"Map        : {CS.MAP_STRINGS[_s_o['map_name']]}")
+                            print(f"Orig. Time : {_s_o['time_elapsed']} ({_old_time} sec.)")
+                            print(f"New Time   : {_s_n['time_elapsed']} ({_new_time} sec.)")
+                            # Record stats and get top player nickname
+                            _top_player = await self.record_player_stats(_s_o)
+                            print(f"Top Player : {_top_player}")
+                            # Send temp message to player stats channel that stats were recorded
+                            _text_channel = self.bot.get_channel(self.bot.config['PlayerStats']['PlayerStatsTextChannelID'])
+                            _embed = discord.Embed(
+                                title="Player Stats Saved!",
+                                description=f"Map Played: *{CS.MAP_STRINGS[_s_o['map_name']]}*\nTop Player: *{self.bot.escape_discord_formatting(_top_player)}*",
+                                color=discord.Colour.green()
+                            )
+                            _embed.set_author(
+                                name=f"\"{_s_o['server_name']}\" has finished a game...", 
+                                icon_url="https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
+                            )
+                            _embed.set_thumbnail(url="https://upload.wikimedia.org/wikipedia/commons/0/04/Save-icon-floppy-disk-transparent-with-circle.png")
+                            _embed.set_footer(text=f"Data captured at final game time of {_s_o['time_elapsed']}")
+                            await _text_channel.send(embed=_embed, delete_after=DEL_STATS_SAVED_MSG_SEC)
+                            # Mark server as being in post game state
+                            self.game_over_ids.append(_s_o['id'])
+                        # Remove server from list if new game started
+                        elif _s_o['id'] in self.game_over_ids and _old_time > _new_time:
+                            print(f"{self.bot.get_datetime_str()}: [PlayerStats] \"{_s_o['server_name']}\" has started a new game on {CS.MAP_STRINGS[_s_n['map_name']]}.")
+                            self.game_over_ids.remove(_s_o['id'])
+                        break
+                # If server has gone offline, record last known data
+                if not _server_found:
+                    print(f"{self.bot.get_datetime_str()}: [PlayerStats] \"{_s_o['server_name']}\" has gone offline!")
+                    await self.record_player_stats(_s_o)
+                    # Remove server from game over list (if it happens to be in there)
+                    if _s_o['id'] in self.game_over_ids:
+                        self.game_over_ids.remove(_s_o['id'])
+        
+        ## Update interval if it differs from config & update channel description
+        _config_interval = self.bot.config['PlayerStats']['QueryIntervalSeconds']
+        if self.StatsLoop.seconds != _config_interval:
+            self.StatsLoop.change_interval(seconds=_config_interval)
+            print(f"{self.bot.get_datetime_str()}: [PlayerStats] Changed loop interval to {self.StatsLoop.seconds} sec.")
+
+
+    """Slash Command Group: /stats
+    
+    A group of commands related to checking player stats.
+    """
+    stats = discord.SlashCommandGroup("stats", "Commands related to checking unofficial player stats")
+
+    @stats.command(name = "player", description="Displays a specific player's unofficial BF2:MC Online stats")
+    @commands.cooldown(1, 180, commands.BucketType.member)
+    async def player(
+        self,
+        ctx,
+        nickname: discord.Option(
+            str, 
+            description="Nickname of player to look up", 
+            autocomplete=discord.utils.basic_autocomplete(get_player_nicknames), 
+            max_length=255, 
+            required=True
+        )
+    ):
+        """Slash Command: /stats player
+        
+        Displays a specific player's unofficial BF2:MC Online stats.
+        """
+        _dbEntry = self.bot.db.getOne(
+            "player_stats", 
+            [
+                "id",
+                "first_seen",
+                "score",
+                "deaths",
+                "us_games",
+                "ch_games",
+                "ac_games",
+                "eu_games",
+                "cq_games",
+                "cf_games",
+                "wins",
+                "losses",
+                "top_player"
+            ], 
+            ("nickname=%s", [nickname])
+        )
+        _escaped_nickname = self.bot.escape_discord_formatting(nickname)
+        if _dbEntry:
+            _rank_data = CS.get_rank_data(_dbEntry['score'])
+            _total_games = _dbEntry['cq_games'] + _dbEntry['cf_games']
+            _fav_gamemode = CS.GM_STRINGS['conquest'] # Default
+            if _dbEntry['cf_games'] > _dbEntry['cq_games']:
+                _fav_gamemode = CS.GM_STRINGS['capturetheflag']
+            _team_games = {
+                CS.TEAM_STRINGS['US'][:-1]: _dbEntry['us_games'],
+                CS.TEAM_STRINGS['CH'][:-1]: _dbEntry['ch_games'],
+                CS.TEAM_STRINGS['AC'][:-1]: _dbEntry['ac_games'],
+                CS.TEAM_STRINGS['EU'][:-1]: _dbEntry['eu_games']
+            }
+            _fav_team = max(_team_games, key=_team_games.get)
+            _ribbons = ""
+            if _total_games >= 50:
+                _ribbons += ":beginner: 50 Games\n"
+            if _total_games >= 250:
+                _ribbons += ":fleur_de_lis: 250 Games\n"
+            if _total_games >= 500:
+                _ribbons += ":trident: 500 Games\n"
+            if _dbEntry['wins'] >= 5:
+                _ribbons += ":third_place: 5 Victories\n"
+            if _dbEntry['wins'] >= 20:
+                _ribbons += ":second_place: 20 Victories\n"
+            if _dbEntry['wins'] >= 50:
+                _ribbons += ":first_place: 50 Victories\n"
+            if _dbEntry['top_player'] >= 5:
+                _ribbons += ":military_medal: 5 Top Player\n"
+            if _dbEntry['top_player'] >= 20:
+                _ribbons += ":medal: 20 Top Player\n"
+            _embed = discord.Embed(
+                title=_escaped_nickname,
+                description=f"*{_rank_data[0]}*",
+                color=discord.Colour.random(seed=_dbEntry['id'])
+            )
+            _embed.set_author(
+                name="BF2:MC Online  |  Player Stats", 
+                icon_url="https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
+            )
+            _embed.set_thumbnail(url=_rank_data[1])
+            _embed.add_field(name="Total Score:", value=_dbEntry['score'], inline=True)
+            _embed.add_field(name="Total Deaths:", value=_dbEntry['deaths'], inline=True)
+            _embed.add_field(name="Ribbons:", value=_ribbons[:-1], inline=True)
+            _embed.add_field(name="Total Games:", value=_total_games, inline=True)
+            _embed.add_field(name="Games Won:", value=_dbEntry['wins'], inline=True)
+            _embed.add_field(name="Games Lost:", value=_dbEntry['losses'], inline=True)
+            _embed.add_field(name="Favorite Team:", value=_fav_team, inline=True)
+            _embed.add_field(name="Favorite Gamemode:", value=_fav_gamemode, inline=True)
+            _embed.set_footer(text=f"First seen online: {_dbEntry['first_seen'].strftime('%m/%d/%Y')} -- Unofficial data*")
+            await ctx.respond(embed=_embed)
+        else:
+            await ctx.respond(f':warning: We have not seen a player by the nickname of "{_escaped_nickname}" play BF2:MC Online since June of 2023.', ephemeral=True)
+
+    """Slash Command Sub-Group: /stats leaderboard
+    
+    A sub-group of commands related to checking the leaderboard for various player stats.
+    """
+    leaderboard = stats.create_subgroup("leaderboard", "Commands related to checking the unofficial leaderboard for various player stats")
+
+    @leaderboard.command(name = "score", description="See an unofficial leaderboard of the top scoring players of BF2:MC Online")
+    @commands.cooldown(1, 180, commands.BucketType.channel)
+    async def score(self, ctx):
+        """Slash Command: /stats leaderboard score
+        
+        Displays an unofficial leaderboard of the top scoring players of BF2:MC Online.
+        """
+        paginator = self.get_paginator_for_stat('score')
+        await paginator.respond(ctx.interaction)
+
+    @leaderboard.command(name = "wins", description="See an unofficial leaderboard of the top winning players of BF2:MC Online")
+    @commands.cooldown(1, 180, commands.BucketType.channel)
+    async def wins(self, ctx):
+        """Slash Command: /stats leaderboard wins
+        
+        Displays an unofficial leaderboard of the top winning players of BF2:MC Online.
+        """
+        paginator = self.get_paginator_for_stat('wins')
+        await paginator.respond(ctx.interaction)
+
+
+def setup(bot):
+    """Called by Pycord to setup the cog"""
+    cog = CogPlayerStats(bot)
+    cog.guild_ids = [bot.config['GuildID']]
+    bot.add_cog(cog)

--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -1,138 +1,37 @@
 """CogServerStatus.py
 
 Handles tasks related to checking server status and info.
-Date: 06/05/2023
+Date: 06/17/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
 
-import json
-import requests
-from datetime import datetime
-
 import discord
 from discord.ext import commands, tasks
 from discord.ext.pages import Paginator, Page
-import inflect
-
-ROOT_URL = "https://stats.bf2mc.net"
-API_URL = "https://stats.bf2mc.net/api/servers/"
-COUNTRY_FLAGS_URL = "https://stats.bf2mc.net/static/img/flags/<code>.png"
-GM_THUMBNAILS_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/gamemode_thumbnails/<gamemode>.png"
-MAP_IMAGES_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/map_images/<map_name>.png"
-STATUS_STRINGS = {
-    "online": "SERVERS: ONLINE 🟢",
-    "offline": "SERVERS: OFFLINE 🔴",
-    "unknown": "SERVERS: UNKNOWN"
-}
-GM_STRINGS = {
-    "conquest": "Conquest",
-    "capturetheflag": "Capture the Flag"
-}
-TEAM_STRINGS = {
-    "US": ":flag_us:  United States:",
-    "CH": ":flag_cn:  China:",
-    "AC": ":flag_ir:  Middle Eastern Coalition:",
-    "EU": ":flag_eu:  European Union:"
-}
-RANK_DATA = {
-    (0, 25): ("Private", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pv2.png"),
-    (25, 50): ("Private 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pfc.png"),
-    (50, 100): ("Corporal", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpl.png"),
-    (100, 150): ("Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgt.png"),
-    (150, 225): ("Sergeant 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sfc.png"),
-    (225, 360): ("Master Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/msg.png"),
-    (360, 550): ("Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgm.png"),
-    (550, 750): ("Command Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/csm.png"),
-    (750, 1050): ("Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/wo1.png"),
-    (1050, 1500): ("Chief Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cw4.png"),
-    (1500, 2000): ("2nd Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/2lt.png"),
-    (2000, 2800): ("1st Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/1lt.png"),
-    (2800, 4000): ("Captain", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpt.png"),
-    (4000, 5800): ("Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/maj.png"),
-    (5800, 8000): ("Lieutenant Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/ltc.png"),
-    (8000, 12000): ("Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/col.png"),
-    (12000, 16000): ("Brigadier General", "https://www.military-ranks.org/images/ranks/army/large/brigadier-general.png"),
-    (16000, 22000): ("Major General", "https://www.military-ranks.org/images/ranks/army/large/major-general.png"),
-    (22000, 32000): ("Lieutenant General", "https://www.military-ranks.org/images/ranks/army/large/lieutenant-general.png"),
-    (32000, float('inf')): ("5 Star General", "https://www.military-ranks.org/images/ranks/army/large/general-of-the-army.png")
-}
-
-P = inflect.engine()
+import common.CommonStrings as CS
 
 
-async def get_player_nicknames(ctx: discord.AutocompleteContext):
-    """Autocomplete Context: Get player nicknames
-    
-    Returns array of all player nicknames in the bot's database.
-    """
-    _dbEntries = ctx.bot.db.getAll(
-        "player_stats", 
-        ["nickname"]
-    )
-    if _dbEntries:
-        return [player['nickname'] for player in _dbEntries]
-    else:
-        return []
+UPDATE_INTERVAL = 1.3 # Minutes
 
 
 class CogServerStatus(discord.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.server_data = None
-        self.last_query = None
         self.total_online = 0
+        self.status_msg = None
         self.server_status = "automatic"
-        #self.bot.db.query("DROP TABLE player_stats") # DEBUGGING
-        self.bot.db.query(
-            "CREATE TABLE IF NOT EXISTS player_stats ("
-                "id INT AUTO_INCREMENT PRIMARY KEY, "
-                "nickname TINYTEXT NOT NULL, "
-                "first_seen DATE NOT NULL, "
-                "score INT NOT NULL, "
-                "deaths INT NOT NULL, "
-                "us_games INT NOT NULL, "
-                "ch_games INT NOT NULL, "
-                "ac_games INT NOT NULL, "
-                "eu_games INT NOT NULL, "
-                "cq_games INT NOT NULL, "
-                "cf_games INT NOT NULL, "
-                "wins INT NOT NULL, "
-                "losses INT NOT NULL, "
-                "top_player INT NOT NULL"
-            ")"
-        )
     
 
-    async def query_api(self):
-        """Query API
-        
-        Returns JSON after querying API URL, or None if bad response.
-        """
-        print(f"{self.bot.get_datetime_str()}: [ServerStatus] Querying API... ", end='')
-
-        # Make an HTTP GET request to the API endpoint
-        _response = requests.get(API_URL)
-
-        # Check if the request was successful (status code 200 indicates success)
-        if _response.status_code == 200:
-            print("Success.")
-            # Parse the JSON response
-            return _response.json()
-        else:
-            print("Failed.")
-            return None
-        #return self.bot.config['TEST'] # DEBUGGING
-    
     def get_team_score_str(self, gamemode: str, score: int) -> str:
         """Get Team Score String
         
         Returns a formatted string for the team's score given the current gamemode.
         """
         if gamemode == "conquest":
-            return f"***{P.no('ticket', score)} remaining***"
+            return f"***{self.bot.infl.no('ticket', score)} remaining***"
         else:
-            return f"***{P.no('flag', score)} captured***"
+            return f"***{self.bot.infl.no('flag', score)} captured***"
     
     def get_player_attr_list_str(self, players: list, attribute: str) -> str:
         """Get Player Attribute List String
@@ -157,9 +56,9 @@ class CogServerStatus(discord.Cog):
         """
         _embeds = []
 
-        if self.server_data != None:
-            if self.server_data['count'] > 0:
-                for s in self.server_data['results']:
+        if self.bot.cur_query_data != None:
+            if self.bot.cur_query_data['count'] > 0:
+                for s in self.bot.cur_query_data['results']:
                     # Get total player count
                     _player_count = len(s['players'])
 
@@ -196,15 +95,15 @@ class CogServerStatus(discord.Cog):
                     )
                     _embed.set_author(
                         name="BF2:MC Server Info", 
-                        icon_url=COUNTRY_FLAGS_URL.replace("<code>", s['country'].lower())
+                        icon_url=CS.COUNTRY_FLAGS_URL.replace("<code>", s['country'].lower())
                     )
-                    _embed.set_thumbnail(url=GM_THUMBNAILS_URL.replace("<gamemode>", s['game_type']))
+                    _embed.set_thumbnail(url=CS.GM_THUMBNAILS_URL.replace("<gamemode>", s['game_type']))
                     _embed.add_field(name="Players:", value=f"{_player_count}/{s['max_players']}", inline=False)
-                    _embed.add_field(name="Gamemode:", value=GM_STRINGS[s['game_type']], inline=True)
+                    _embed.add_field(name="Gamemode:", value=CS.GM_STRINGS[s['game_type']], inline=True)
                     _embed.add_field(name="Time Elapsed:", value=s['time_elapsed'][3:], inline=True)
                     _embed.add_field(name="Time Limit:", value=s['time_limit'][3:], inline=True)
                     _embed.add_field(
-                        name=TEAM_STRINGS[s['team1_country']], 
+                        name=CS.TEAM_STRINGS[s['team1_country']], 
                         value=self.get_team_score_str(s['game_type'], s['team1_score']), 
                         inline=False
                     )
@@ -212,15 +111,15 @@ class CogServerStatus(discord.Cog):
                     _embed.add_field(name="Score:", value=self.get_player_attr_list_str(_team1, 'score'), inline=True)
                     _embed.add_field(name="Deaths:", value=self.get_player_attr_list_str(_team1, 'deaths'), inline=True)
                     _embed.add_field(
-                        name=TEAM_STRINGS[s['team2_country']], 
+                        name=CS.TEAM_STRINGS[s['team2_country']], 
                         value=self.get_team_score_str(s['game_type'], s['team2_score']), 
                         inline=False
                     )
                     _embed.add_field(name="Player:", value=self.get_player_attr_list_str(_team2, 'name'), inline=True)
                     _embed.add_field(name="Score:", value=self.get_player_attr_list_str(_team2, 'score'), inline=True)
                     _embed.add_field(name="Deaths:", value=self.get_player_attr_list_str(_team2, 'deaths'), inline=True)
-                    _embed.set_image(url=MAP_IMAGES_URL.replace("<map_name>", s['map_name']))
-                    _embed.set_footer(text=f"Data fetched at: {self.last_query.strftime('%I:%M:%S %p UTC')} -- {ROOT_URL}")
+                    _embed.set_image(url=CS.MAP_IMAGES_URL.replace("<map_name>", s['map_name']))
+                    _embed.set_footer(text=f"Data fetched at: {self.bot.last_query.strftime('%I:%M:%S %p UTC')} -- {self.bot.config['API']['RootURL']}")
                     _embeds.append(_embed)
             else:
                 _description = f"""
@@ -233,7 +132,7 @@ class CogServerStatus(discord.Cog):
                     color=discord.Colour.red()
                 )
                 _embed.set_thumbnail(url="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/Computer_crash.svg/1200px-Computer_crash.svg.png")
-                _embed.set_footer(text=f"Data fetched at: {self.last_query.strftime('%I:%M:%S %p UTC')} -- {ROOT_URL}")
+                _embed.set_footer(text=f"Data fetched at: {self.bot.last_query.strftime('%I:%M:%S %p UTC')} -- {self.bot.config['API']['RootURL']}")
                 _embeds.append(_embed)
         else:
             _description = """
@@ -249,179 +148,10 @@ class CogServerStatus(discord.Cog):
                     color=discord.Colour.yellow()
                 )
             _embed.set_thumbnail(url="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/Computer_crash.svg/1200px-Computer_crash.svg.png")
-            _embed.set_footer(text=f"Data fetched at: {self.last_query.strftime('%I:%M:%S %p UTC')} -- {ROOT_URL}")
+            _embed.set_footer(text=f"Data fetched at: {self.bot.last_query.strftime('%I:%M:%S %p UTC')} -- {self.bot.config['API']['RootURL']}")
             _embeds.append(_embed)
         
         return _embeds
-    
-    async def record_player_stats(self, server_data: dict) -> str:
-        """Record Player Statistics
-        
-        Additively records player statistics to the database given a server's JSON data.
-        New records are created for first-seen players.
-        Returns nickname string of the top player.
-        """
-        print(f"Recording round stats... ", end='')
-
-        # Sanitize input (because I'm paranoid)
-        if server_data == None or len(server_data['players']) < 2:
-            return
-        
-        # Calculate top player
-        _top_player = None
-        for _p in server_data['players']:
-            if (_top_player == None
-                or _p['score'] > _top_player['score']
-                or (_p['score'] == _top_player['score'] and _p['deaths'] < _top_player['deaths'])):
-                _top_player = _p
-        _top_player = _top_player['name']
-
-        # Calculate and record stats for each player in game
-        for _p in server_data['players']:
-            _dbEntry = self.bot.db.getOne(
-                "player_stats", 
-                [
-                    "id",
-                    "score",
-                    "deaths",
-                    "us_games",
-                    "ch_games",
-                    "ac_games",
-                    "eu_games",
-                    "cq_games",
-                    "cf_games",
-                    "wins",
-                    "losses",
-                    "top_player"
-                ], 
-                ("nickname=%s", [_p['name']])
-            )
-            
-            # Sum round stats with existing player stats
-            if _dbEntry == None:
-                _summed_stats = {
-                    "score": 0,
-                    "deaths": 0,
-                    "us_games": 0,
-                    "ch_games": 0,
-                    "ac_games": 0,
-                    "eu_games": 0,
-                    "cq_games": 0,
-                    "cf_games": 0,
-                    "wins": 0,
-                    "losses": 0,
-                    "top_player": 0
-                }
-            else:
-                _summed_stats = _dbEntry.copy()
-            # Add scores and deaths
-            _summed_stats['score'] += _p['score']
-            _summed_stats['deaths'] += _p['deaths']
-            # Detect player's team and if that team won or lost (draws are omitted)
-            if _p['team'] == 0:
-                _team = server_data['team1_country']
-                if server_data['team1_score'] > server_data['team2_score']:
-                    _summed_stats['wins'] += 1
-                elif server_data['team1_score'] < server_data['team2_score']:
-                    _summed_stats['losses'] += 1
-            else:
-                _team = server_data['team2_country']
-                if server_data['team1_score'] < server_data['team2_score']:
-                    _summed_stats['wins'] += 1
-                elif server_data['team1_score'] > server_data['team2_score']:
-                    _summed_stats['losses'] += 1
-            # Add team they played for
-            if _team == "US":
-                _summed_stats['us_games'] += 1
-            elif _team == "CH":
-                _summed_stats['ch_games'] += 1
-            elif _team == "AC":
-                _summed_stats['ac_games'] += 1
-            else:
-                _summed_stats['eu_games'] += 1
-            # Add gamemode they played
-            if server_data['game_type'] == "capturetheflag":
-                _summed_stats['cf_games'] += 1
-            else:
-                _summed_stats['cq_games'] += 1
-            # Add if they were the top player
-            if _p['name'] == _top_player:
-                _summed_stats['top_player'] += 1
-            
-            # Update player
-            if _dbEntry != None:
-                self.bot.db.update("player_stats", _summed_stats, [f"id={_dbEntry['id']}"])
-            # Insert new player
-            else:
-                _summed_stats['nickname'] = _p['name']
-                _summed_stats['first_seen'] = datetime.now().date()
-                self.bot.db.insert("player_stats", _summed_stats)
-        
-        print("Done.")
-        return _top_player
-    
-    def split_list(self, lst: list, chunk_size: int) -> list[list]:
-        """Split a list into smaller lists of equal size"""
-        if chunk_size <= 0:
-            return [lst]
-        else:
-            num_chunks = len(lst) // chunk_size
-            remainder = len(lst) % chunk_size
-            result = [lst[i*chunk_size:(i+1)*chunk_size] for i in range(num_chunks)]
-            if remainder:
-                result.append(lst[-remainder:])
-            return result
-    
-    def get_paginator_for_stat(self, stat: str) -> Paginator:
-        """Returns a Leaderboard style Paginator for a given database stat"""
-        _rank = 1
-        _pages = []
-        _dbEntries = self.bot.db.getAll("player_stats", ["nickname", stat], None, [stat, "DESC"], [0, 50]) # Limit to top 50 players
-        if _dbEntries:
-            _dbEntries = self.split_list(_dbEntries, 10) # Split into pages of 10 entries each
-            for _page in _dbEntries:
-                _embed = discord.Embed(
-                    title=f":first_place:  BF2:MC Online | Top {stat.capitalize()} Leaderboard  :first_place:",
-                    description=f"*Unofficial\* top 50 players across all servers.*",
-                    color=discord.Colour.gold()
-                )
-                _nicknames = "```\n"
-                _stats = "```\n"
-                for _e in _page:
-                    _rank_str = f"#{_rank}"
-                    _nicknames += f"{_rank_str.ljust(3)} | {_e['nickname']}\n"
-                    if stat == 'score':
-                        _stats += f"{str(_e[stat]).rjust(5)} pts.\n"
-                    elif stat == 'wins':
-                        _stats += f" {P.no('game', _e[stat])} won\n"
-                    else:
-                        _stats += "\n"
-                    _rank += 1
-                _nicknames += "```"
-                _stats += "```"
-                _embed.add_field(name="Player:", value=_nicknames, inline=True)
-                _embed.add_field(name=f"{stat.capitalize()}:", value=_stats, inline=True)
-                _embed.set_footer(text=f"*Some match final moments may be ommited -- {ROOT_URL}")
-                _pages.append(Page(embeds=[_embed]))
-        else:
-            _embed = discord.Embed(
-                title=f":first_place:  BF2:MC Online | Top {stat.capitalize()} Leaderboard*  :first_place:",
-                description="No stats yet.",
-                color=discord.Colour.gold()
-            )
-            _pages = [Page(embeds=[_embed])]
-        return Paginator(pages=_pages, author_check=False)
-    
-    def get_rank_data(self, score: int) -> tuple:
-        """Returns rank name and image as a tuple given a score"""
-        for score_range, rank_data in RANK_DATA.items():
-            if score_range[0] <= score < score_range[1]:
-                return rank_data
-    
-    def time_to_sec(self, time: str) -> int:
-        """Turns a time string into seconds as an integer"""
-        hours, minutes, seconds = time.split(':')
-        return int(hours) * 3600 + int(minutes) * 60 + int(seconds)
     
     async def set_status_channel_name(self, status: str):
         """Set Status Channel Name
@@ -431,9 +161,9 @@ class CogServerStatus(discord.Cog):
         NOTE: Discord limits channel name changes to twice every 10 min.
         """
         _voice_channel = self.bot.get_channel(self.bot.config['ServerStatus']['StatusVoiceChannelID'])
-        if status in STATUS_STRINGS and _voice_channel.name != STATUS_STRINGS[status]:
-            print(f"{self.bot.get_datetime_str()}: [ServerStatus] {STATUS_STRINGS[status]}")
-            await _voice_channel.edit(name=STATUS_STRINGS[status], reason="[BackstabBot] Server status updated.")
+        if status in CS.STATUS_STRINGS and _voice_channel.name != CS.STATUS_STRINGS[status]:
+            print(f"{self.bot.get_datetime_str()}: [ServerStatus] {CS.STATUS_STRINGS[status]}")
+            await _voice_channel.edit(name=CS.STATUS_STRINGS[status], reason="[BackstabBot] Server status updated.")
 
 
     @commands.Cog.listener()
@@ -445,86 +175,46 @@ class CogServerStatus(discord.Cog):
         print(f"{self.bot.get_datetime_str()}: [ServerStatus] Successfully cached!")
         
         # Check that all channels in the config are valid
-        _cfg_keys = [
+        _cfg_sub_keys = [
             'StatusVoiceChannelID',
             'ServerStatsTextChannelID',
-            'PlayerStatsTextChannelID',
             'AnnouncementTextChannelID'
         ]
-        for _key in _cfg_keys:
-            _channel_id = self.bot.config['ServerStatus'][_key]
-            if self.bot.get_channel(_channel_id) == None:
-                print(f"ERROR: [Config] Could not find valid channel with ID: {_channel_id}")
-                await self.bot.close()
+        await self.bot.check_channel_ids_for_cfg_key('ServerStatus', _cfg_sub_keys)
+
+        # Get status message (if it exists) from message history (if we haven't already)
+        if self.status_msg == None:
+            _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
+            async for _m in _text_channel.history(limit=3):
+                # Check if the message was sent by the user
+                if _m.author == self.bot.user:
+                    self.status_msg = await _text_channel.fetch_message(_m.id)
+                    break
         
         # Start Status Loop
         if not self.StatusLoop.is_running():
-            _config_interval = self.bot.config['ServerStatus']['UpdateIntervalMinutes']
-            self.StatusLoop.change_interval(minutes=_config_interval)
             self.StatusLoop.start()
-            print(f"{self.bot.get_datetime_str()}: [ServerStatus] StatusLoop started ({_config_interval} min. interval).")
+            print(f"{self.bot.get_datetime_str()}: [ServerStatus] StatusLoop started ({UPDATE_INTERVAL} min. interval).")
+            # Set channel description if it is not correct
+            _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
+            _topic = f"Live server statistics (Updated every {self.bot.infl.no('second', round(UPDATE_INTERVAL*60))})"
+            if _text_channel.topic != _topic:
+                await _text_channel.edit(topic=_topic)
     
 
-    @tasks.loop(minutes=5)
+    @tasks.loop(minutes=UPDATE_INTERVAL)
     async def StatusLoop(self):
         """Task Loop: Status Loop
         
-        Runs every interval period, queries API, updates status voice channel, and updates info text channel.
+        Runs every interval period, references bot's latest query data, 
+        updates status voice channel, and updates info text channel.
         """
-        ## Query API for data
-        _new_data = await self.query_api()
-        self.last_query = datetime.utcnow()
-
-        ## Check each server if game over -> record stats
-        # Only check if original data exists
-        if self.server_data != None:
-            # For all existing servers...
-            for _s_o in self.server_data['results']:
-                _server_found = False
-                # Search all new data for matching server
-                for _s_n in _new_data['results']:
-                    if _s_o['id'] == _s_n['id']:
-                        _server_found = True
-                        # Record original data if new time elapsed is lower (indicating a new game)
-                        # and there is more than 1 player (not real game)
-                        _original_time = self.time_to_sec(_s_o['time_elapsed'])
-                        _new_time = self.time_to_sec(_s_n['time_elapsed'])
-                        if _original_time > _new_time and len(_s_o['players']) > 1:
-                            print(f"{self.bot.get_datetime_str()}: [ServerStatus] A server has finished a game:")
-                            print(f"Server     : {_s_o['server_name']}")
-                            print(f"Map        : {_s_o['map_name']}")
-                            print(f"Orig. Time : {_s_o['time_elapsed']} ({_original_time} sec.)")
-                            print(f"New Time   : {_s_n['time_elapsed']} ({_new_time} sec.)")
-                            # Record stats and get top player nickname
-                            _top_player = await self.record_player_stats(_s_o)
-                            print(f"Top Player : {_top_player}")
-                            # Send temp message to player stats channel that stats were recorded
-                            _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['PlayerStatsTextChannelID'])
-                            _embed = discord.Embed(
-                                title="Player Stats Saved!",
-                                description=f"Map Played: *{_s_o['map_name']}*\nTop Player: *{self.bot.escape_discord_formatting(_top_player)}*",
-                                color=discord.Colour.green()
-                            )
-                            _embed.set_author(
-                                name=f"\"{_s_o['server_name']}\" has finished a game...", 
-                                icon_url="https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
-                            )
-                            _embed.set_thumbnail(url="https://upload.wikimedia.org/wikipedia/commons/0/04/Save-icon-floppy-disk-transparent-with-circle.png")
-                            _embed.set_footer(text=f"Data captured at final game time of {_s_o['time_elapsed']}")
-                            await _text_channel.send(embed=_embed, delete_after=60)
-                        break
-                # If server has gone offline, record last known data
-                if not _server_found:
-                    print(f"{self.bot.get_datetime_str()}: [ServerStatus] \"{_s_o['server_name']}\" has gone offline!")
-                    await self.record_player_stats(_s_o)
-        # Replace original data with new data
-        self.server_data = _new_data
-        
         ## Calculate total players online
         _total_online = 0
-        for _s in self.server_data['results']:
-            for _ in _s['players']:
-                _total_online += 1
+        if self.bot.cur_query_data != None:
+            for _s in self.bot.cur_query_data['results']:
+                for _ in _s['players']:
+                    _total_online += 1
         
         ## Update bot's activity if total players has changed
         if _total_online != self.total_online:
@@ -534,9 +224,9 @@ class CogServerStatus(discord.Cog):
 
         ## Update status channel name
         if self.server_status == "automatic":
-            if self.server_data == None:
+            if self.bot.cur_query_data == None:
                 await self.set_status_channel_name("unknown")
-            elif self.server_data['count'] > 0:
+            elif self.bot.cur_query_data['count'] > 0:
                 await self.set_status_channel_name("online")
             else:
                 await self.set_status_channel_name("offline")
@@ -548,25 +238,14 @@ class CogServerStatus(discord.Cog):
             await self.set_status_channel_name("unknown")
 
         ## Update stats channel post
-        _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
-        _last_message = None
-        # Fetch the message history of the channel
-        async for _m in _text_channel.history(limit=3):
-            # Check if the message was sent by the user
-            if _m.author == self.bot.user:
-                _last_message = await _text_channel.fetch_message(_m.id)
-                break
-        if _last_message != None:
-            await _last_message.edit(f"## Total Players: {self.total_online}", embeds=self.get_server_stat_embeds())
+        if self.status_msg != None:
+            try:
+                await self.status_msg.edit(f"## Total Players: {self.total_online}", embeds=self.get_server_stat_embeds())
+            except:
+                pass
         else:
+            _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
             await _text_channel.send(f"## Total Players: {self.total_online}", embeds=self.get_server_stat_embeds())
-        
-        ## Update interval if it differs from config & update channel description
-        _config_interval = self.bot.config['ServerStatus']['UpdateIntervalMinutes']
-        if self.StatusLoop.minutes != _config_interval:
-            await _text_channel.edit(topic=f"Live server statistics (Updated every {P.no('second', round(_config_interval*60))})")
-            self.StatusLoop.change_interval(minutes=_config_interval)
-            print(f"{self.bot.get_datetime_str()}: [ServerStatus] Changed loop interval to {self.StatusLoop.minutes} min.")
 
 
     """Slash Command Group: /server
@@ -582,109 +261,12 @@ class CogServerStatus(discord.Cog):
         Reports number of live BF2:MC servers (since last status check).
         Useful as backup if status channel has hit it's rate limit.
         """
-        if self.server_data != None:
-            await ctx.respond(f"Number of live BF2:MC servers: {self.server_data['count']}", ephemeral=True)
+        if self.bot.cur_query_data != None:
+            await ctx.respond(f"Number of live BF2:MC servers: {self.bot.cur_query_data['count']}", ephemeral=True)
         else:
             raise commands.CommandError("There was an error retrieving this data. The statistics API may be down at the moment.")
-
-
-    """Slash Command Group: /stats
     
-    A group of commands related to checking player stats.
-    """
-    stats = discord.SlashCommandGroup("stats", "Commands related to checking unofficial player stats")
-
-    @stats.command(name = "player", description="Displays a specific player's unofficial BF2:MC Online stats")
-    @commands.cooldown(1, 180, commands.BucketType.member)
-    async def player(
-        self,
-        ctx,
-        nickname: discord.Option(
-            str, 
-            description="Nickname of player to look up", 
-            autocomplete=discord.utils.basic_autocomplete(get_player_nicknames), 
-            max_length=255, 
-            required=True
-        )
-    ):
-        """Slash Command: /stats player
-        
-        Displays a specific player's unofficial BF2:MC Online stats.
-        """
-        _dbEntry = self.bot.db.getOne(
-            "player_stats", 
-            [
-                "id",
-                "first_seen",
-                "score",
-                "deaths",
-                "us_games",
-                "ch_games",
-                "ac_games",
-                "eu_games",
-                "cq_games",
-                "cf_games",
-                "wins",
-                "losses",
-                "top_player"
-            ], 
-            ("nickname=%s", [nickname])
-        )
-        _escaped_nickname = self.bot.escape_discord_formatting(nickname)
-        if _dbEntry:
-            _rank_data = self.get_rank_data(_dbEntry['score'])
-            _total_games = _dbEntry['cq_games'] + _dbEntry['cf_games']
-            _fav_gamemode = GM_STRINGS['conquest'] # Default
-            if _dbEntry['cf_games'] > _dbEntry['cq_games']:
-                _fav_gamemode = GM_STRINGS['capturetheflag']
-            _team_games = {
-                TEAM_STRINGS['US'][:-1]: _dbEntry['us_games'],
-                TEAM_STRINGS['CH'][:-1]: _dbEntry['ch_games'],
-                TEAM_STRINGS['AC'][:-1]: _dbEntry['ac_games'],
-                TEAM_STRINGS['EU'][:-1]: _dbEntry['eu_games']
-            }
-            _fav_team = max(_team_games, key=_team_games.get)
-            _ribbons = ""
-            if _total_games >= 50:
-                _ribbons += ":beginner: 50 Games\n"
-            if _total_games >= 250:
-                _ribbons += ":fleur_de_lis: 250 Games\n"
-            if _total_games >= 500:
-                _ribbons += ":trident: 500 Games\n"
-            if _dbEntry['wins'] >= 5:
-                _ribbons += ":third_place: 5 Victories\n"
-            if _dbEntry['wins'] >= 20:
-                _ribbons += ":second_place: 20 Victories\n"
-            if _dbEntry['wins'] >= 50:
-                _ribbons += ":first_place: 50 Victories\n"
-            if _dbEntry['top_player'] >= 5:
-                _ribbons += ":military_medal: 5 Top Player\n"
-            if _dbEntry['top_player'] >= 20:
-                _ribbons += ":medal: 20 Top Player\n"
-            _embed = discord.Embed(
-                title=_escaped_nickname,
-                description=f"*{_rank_data[0]}*",
-                color=discord.Colour.random(seed=_dbEntry['id'])
-            )
-            _embed.set_author(
-                name="BF2:MC Online  |  Player Stats", 
-                icon_url="https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
-            )
-            _embed.set_thumbnail(url=_rank_data[1])
-            _embed.add_field(name="Total Score:", value=_dbEntry['score'], inline=True)
-            _embed.add_field(name="Total Deaths:", value=_dbEntry['deaths'], inline=True)
-            _embed.add_field(name="Ribbons:", value=_ribbons[:-1], inline=True)
-            _embed.add_field(name="Total Games:", value=_total_games, inline=True)
-            _embed.add_field(name="Games Won:", value=_dbEntry['wins'], inline=True)
-            _embed.add_field(name="Games Lost:", value=_dbEntry['losses'], inline=True)
-            _embed.add_field(name="Favorite Team:", value=_fav_team, inline=True)
-            _embed.add_field(name="Favorite Gamemode:", value=_fav_gamemode, inline=True)
-            _embed.set_footer(text=f"First seen online: {_dbEntry['first_seen'].strftime('%m/%d/%Y')} -- Unofficial data*")
-            await ctx.respond(embed=_embed)
-        else:
-            await ctx.respond(f':warning: We have not seen a player by the nickname of "{_escaped_nickname}" play BF2:MC Online since June of 2023.', ephemeral=True)
-    
-    @stats.command(name = "setstatus", description="Manually set the global server status, or set it to automatically update. Only admins can do this.")
+    @server.command(name = "setstatus", description="Manually set the global server status, or set it to automatically update. Only admins can do this.")
     @discord.default_permissions(manage_channels=True) # Only members with Manage Channels permission can use this command.
     @commands.cooldown(2, 600, commands.BucketType.guild) # Discord limits channel name changes to twice every 10 min.
     async def setstatus(
@@ -697,42 +279,16 @@ class CogServerStatus(discord.Cog):
             required=True
         )
     ):
-        """Slash Command: /stats setstatus
+        """Slash Command: /server setstatus
         
         Manually sets the global server status, or sets it to automatically update. Only admins can do this.
         """
         self.server_status = status
         status = status.capitalize()
         _msg = f"Global server status set to: {status}"
-        _msg += f"\n\n(Please allow up to {P.no('second', self.bot.config['ServerStatus']['UpdateIntervalMinutes']*60)} for the status to change)"
+        _msg += f"\n\n(Please allow up to {self.bot.infl.no('second', UPDATE_INTERVAL*60)} for the status to change)"
         await ctx.respond(_msg, ephemeral=True)
-        print(f"{self.bot.get_datetime_str()}: [ServerStatus] {ctx.author.name} set the global server status to: {status}")
-
-    """Slash Command Sub-Group: /stats leaderboard
-    
-    A sub-group of commands related to checking the leaderboard for various player stats.
-    """
-    leaderboard = stats.create_subgroup("leaderboard", "Commands related to checking the unofficial leaderboard for various player stats")
-
-    @leaderboard.command(name = "score", description="See an unofficial leaderboard of the top scoring players of BF2:MC Online")
-    @commands.cooldown(1, 180, commands.BucketType.channel)
-    async def score(self, ctx):
-        """Slash Command: /stats leaderboard score
-        
-        Displays an unofficial leaderboard of the top scoring players of BF2:MC Online.
-        """
-        paginator = self.get_paginator_for_stat('score')
-        await paginator.respond(ctx.interaction)
-
-    @leaderboard.command(name = "wins", description="See an unofficial leaderboard of the top winning players of BF2:MC Online")
-    @commands.cooldown(1, 180, commands.BucketType.channel)
-    async def wins(self, ctx):
-        """Slash Command: /stats leaderboard wins
-        
-        Displays an unofficial leaderboard of the top winning players of BF2:MC Online.
-        """
-        paginator = self.get_paginator_for_stat('wins')
-        await paginator.respond(ctx.interaction)
+        print(f"{self.bot.get_datetime_str()}: [PlayerStats] {ctx.author.name} set the global server status to: {status}")
 
 
 def setup(bot):

--- a/common/CommonStrings.py
+++ b/common/CommonStrings.py
@@ -1,0 +1,70 @@
+"""CommonStrings.py
+
+Collection of commonly used public static final strings and related functions.
+Date: 06/07/2023
+Authors: David Wolfe (Red-Thirten)
+Licensed under GNU GPLv3 - See LICENSE for more details.
+"""
+
+COUNTRY_FLAGS_URL = "https://stats.bf2mc.net/static/img/flags/<code>.png"
+GM_THUMBNAILS_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/gamemode_thumbnails/<gamemode>.png"
+MAP_IMAGES_URL = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/map_images/<map_name>.png"
+STATUS_STRINGS = {
+    "online": "SERVERS: ONLINE 🟢",
+    "offline": "SERVERS: OFFLINE 🔴",
+    "unknown": "SERVERS: UNKNOWN"
+}
+GM_STRINGS = {
+    "conquest": "Conquest",
+    "capturetheflag": "Capture the Flag"
+}
+TEAM_STRINGS = {
+    "US": ":flag_us:  United States:",
+    "CH": ":flag_cn:  China:",
+    "AC": ":flag_ir:  Middle Eastern Coalition:",
+    "EU": ":flag_eu:  European Union:"
+}
+MAP_STRINGS = {
+    "backstab": "Backstab",
+    "bridgetoofar": "Bridge Too Far",
+    "coldfront": "Cold Front",
+    "dammage": "Dammage",
+    "deadlypass": "Deadly Pass",
+    "harboredge": "Harbor Edge",
+    "honor": "Honor",
+    "littlebigeye": "Little Big Eye",
+    "missilecrisis": "Missile Crisis",
+    "russianborder": "Russian Border",
+    "specialop": "Special Op",
+    "theblackgold": "The Black Gold",
+    "thenest": "The Nest"
+}
+RANK_DATA = {
+    (0, 25): ("Private", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pv2.png"),
+    (25, 50): ("Private 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pfc.png"),
+    (50, 100): ("Corporal", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpl.png"),
+    (100, 150): ("Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgt.png"),
+    (150, 225): ("Sergeant 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sfc.png"),
+    (225, 360): ("Master Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/msg.png"),
+    (360, 550): ("Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgm.png"),
+    (550, 750): ("Command Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/csm.png"),
+    (750, 1050): ("Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/wo1.png"),
+    (1050, 1500): ("Chief Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cw4.png"),
+    (1500, 2000): ("2nd Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/2lt.png"),
+    (2000, 2800): ("1st Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/1lt.png"),
+    (2800, 4000): ("Captain", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpt.png"),
+    (4000, 5800): ("Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/maj.png"),
+    (5800, 8000): ("Lieutenant Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/ltc.png"),
+    (8000, 12000): ("Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/col.png"),
+    (12000, 16000): ("Brigadier General", "https://www.military-ranks.org/images/ranks/army/large/brigadier-general.png"),
+    (16000, 22000): ("Major General", "https://www.military-ranks.org/images/ranks/army/large/major-general.png"),
+    (22000, 32000): ("Lieutenant General", "https://www.military-ranks.org/images/ranks/army/large/lieutenant-general.png"),
+    (32000, float('inf')): ("5 Star General", "https://www.military-ranks.org/images/ranks/army/large/general-of-the-army.png")
+}
+
+
+def get_rank_data(score: int) -> tuple:
+    """Returns rank name and image as a tuple given a score"""
+    for score_range, rank_data in RANK_DATA.items():
+        if score_range[0] <= score < score_range[1]:
+            return rank_data

--- a/config-example.cfg
+++ b/config-example.cfg
@@ -8,12 +8,18 @@
         "Pass": "PASSWORD_HERE",
         "DB_Name": "DATABASE_NAME_HERE"
     },
+    "API": {
+        "RootURL": "https://stats.bf2mc.net",
+        "ApiURL": "https://stats.bf2mc.net/api/servers/"
+    },
     "ServerStatus": {
         "StatusVoiceChannelID": 012345678901234567,
         "ServerStatsTextChannelID": 012345678901234567,
-        "PlayerStatsTextChannelID": 012345678901234567,
         "AnnouncementTextChannelID": 012345678901234567,
-        "UpdateIntervalMinutes": 1.5,
         "OfficialIDs": [1, 3]
+    }
+    "PlayerStats": {
+        "PlayerStatsTextChannelID": 012345678901234567,
+        "QueryIntervalSeconds": 10
     }
 }

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 06/05/2023
+Date: 06/17/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,9 +13,10 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.1.6"
+    VERSION = "2.2.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
+        "CogPlayerStats",
         "CogServerStatus"
     ]
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,18 +1,20 @@
 """bot.py
 
 A subclass of `discord.Bot` that adds ease-of-use instance variables and functions (e.g. database object).
-Date: 06/05/2023
+Date: 06/11/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
 
 import sys
 import json
+import requests
 from datetime import datetime
 
 import discord
 from discord.ext import commands
 from simplemysql import SimpleMysql
+import inflect
 
 
 class BackstabBot(discord.Bot):
@@ -44,6 +46,10 @@ class BackstabBot(discord.Bot):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.config = BackstabBot.get_config()
+        self.cur_query_data = None
+        self.old_query_data = None
+        self.last_query = None
+        self.infl = inflect.engine()
         # Database Initialization
         try:
             print(f"{BackstabBot.get_datetime_str()}: [Startup] Logging into MySQL database... ", end='')
@@ -88,3 +94,51 @@ class BackstabBot(discord.Bot):
     def reload_config(self):
         """Reloads config from file and reassigns its data to the bot"""
         self.config = BackstabBot.get_config()
+    
+    async def check_channel_ids_for_cfg_key(self, key: str, sub_keys: list):
+        """Check Channel IDs for given Config Key
+
+        Check channel ID validity for given list of sub-keys in the config.
+        Displays an error and closes the bot if an ID is invalid.
+        """
+        for _sub_key in sub_keys:
+            _channel_id = self.config[key][_sub_key]
+            if self.get_channel(_channel_id) == None:
+                print(f"ERROR: [Config] Could not find valid channel with ID: {_channel_id}")
+                await self.close()
+    
+    async def query_api(self) -> dict:
+        """Query API
+        
+        Returns JSON after querying API URL, or None if bad response.
+        Also sets instance variables query_data and last_query.
+        """
+        print(f"{self.get_datetime_str()}: [General] Querying API... ", end='')
+
+        # DEBUGGING
+        try:
+            _DEBUG = self.config['DEBUG']
+        except:
+            _DEBUG = None
+
+        # Move current data to old data
+        self.old_query_data = self.cur_query_data
+
+        # Make an HTTP GET request to the API endpoint
+        if not _DEBUG:
+            _response = requests.get(self.config['API']['ApiURL'])
+        self.last_query = datetime.utcnow()
+
+        # Check if the request was successful (status code 200 indicates success)
+        if _DEBUG:
+            self.cur_query_data = _DEBUG
+            print("Success (DEBUG).")
+        elif _response.status_code == 200:
+            print("Success.")
+            # Parse the JSON response
+            self.cur_query_data = _response.json()
+        else:
+            print("Failed!")
+            self.cur_query_data = None
+        
+        return self.cur_query_data


### PR DESCRIPTION
- Split all player stats recording to its own Cog for better organization.
- Stats now record when the time elapsed has paused (and server has more than 1 player), which should be a better indicator of a game end, and will make sure to capture true end of game stats (including top player). When the time resets, this will indicate a new game has started.
- Server Status and Player Stats are polled at two different rates now. Player stats are queried faster to obtain true end game stats. Status is acquired from this data at a slower rate to not exceed Discord's message edit rate limit.
- API querying, query data, and the Inflect object have all been moved to the bot subclass to be global.
- Moved the status text channel object to be a Cog instance variable so it doesn't have to be found every loop. Also added an attempt to handle an error with editing the message when the Discord API goes down.
- Changed `/stats setstatus` to `/server setstatus`
- Moved all common strings and string functions to CommonStrings, which the Cogs now utilize.
- Re-orginized config file.