### PR TITLE
[v2.3.0] Add Most Played Map Stats & Total Player Count Command 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ config.cfg
 
 # Local dev files
 TODO.txt
+db_backups/
 
 # Python compiled bytecode and cache
 **/__pycache__/

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 06/18/2023
+Date: 06/29/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -522,7 +522,7 @@ class CogPlayerStats(discord.Cog):
 
         if _dbEntries != None:
             _embed = discord.Embed(
-                title=f"🗺 Most Played {gamemode} Map",
+                title=f"🗺  Most Played {gamemode} Map",
                 description=f"*Currently, the most played {gamemode} map is...*",
                 color=discord.Colour.dark_blue()
             )
@@ -531,6 +531,33 @@ class CogPlayerStats(discord.Cog):
             await ctx.respond(embed=_embed)
         else:
             await ctx.respond(f":warning: No data for {gamemode} yet. Please try again later.", ephemeral=True)
+
+    """Slash Command Sub-Group: /stats total
+    
+    A sub-group of commands related to checking "total count" stats.
+    """
+    total = stats.create_subgroup("total", 'Commands related to checking "total count" related stats')
+    
+    @total.command(name = "playercount", description="Displays the count of unique nicknames with recorded stats")
+    @commands.cooldown(1, 1800, commands.BucketType.channel)
+    async def playercount(self, ctx):
+        """Slash Command: /stats total playercount
+        
+        Displays the count of unique nicknames with recorded stats.
+        """
+        _dbEntries = self.bot.db.getAll("player_stats", ["id"])
+
+        _total_players = 0
+        if _dbEntries != None:
+            _total_players = len(_dbEntries)
+        
+        _embed = discord.Embed(
+            title=f"👥︎  Total Player Count (All-Time)",
+            description=f"I have tracked **{_total_players}** unique nicknames play at least one game since June of 2023*",
+            color=discord.Colour.dark_blue()
+        )
+        _embed.set_footer(text="*Real player count may be lower due to player's having multiple accounts")
+        await ctx.respond(embed=_embed)
 
 
 def setup(bot):

--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -1,7 +1,7 @@
 """CogServerStatus.py
 
 Handles tasks related to checking server status and info.
-Date: 06/17/2023
+Date: 06/29/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -240,12 +240,12 @@ class CogServerStatus(discord.Cog):
         ## Update stats channel post
         if self.status_msg != None:
             try:
-                await self.status_msg.edit(f"## Total Players: {self.total_online}", embeds=self.get_server_stat_embeds())
+                await self.status_msg.edit(f"## Total Players Online: {self.total_online}", embeds=self.get_server_stat_embeds())
             except:
                 pass
         else:
             _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
-            await _text_channel.send(f"## Total Players: {self.total_online}", embeds=self.get_server_stat_embeds())
+            await _text_channel.send(f"## Total Players Online: {self.total_online}", embeds=self.get_server_stat_embeds())
 
 
     """Slash Command Group: /server

--- a/common/CommonStrings.py
+++ b/common/CommonStrings.py
@@ -1,7 +1,7 @@
 """CommonStrings.py
 
 Collection of commonly used public static final strings and related functions.
-Date: 06/07/2023
+Date: 06/18/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -24,20 +24,20 @@ TEAM_STRINGS = {
     "AC": ":flag_ir:  Middle Eastern Coalition:",
     "EU": ":flag_eu:  European Union:"
 }
-MAP_STRINGS = {
-    "backstab": "Backstab",
-    "bridgetoofar": "Bridge Too Far",
-    "coldfront": "Cold Front",
-    "dammage": "Dammage",
-    "deadlypass": "Deadly Pass",
-    "harboredge": "Harbor Edge",
-    "honor": "Honor",
-    "littlebigeye": "Little Big Eye",
-    "missilecrisis": "Missile Crisis",
-    "russianborder": "Russian Border",
-    "specialop": "Special Op",
-    "theblackgold": "The Black Gold",
-    "thenest": "The Nest"
+MAP_DATA = {
+    "backstab": ("Backstab", 0),
+    "bridgetoofar": ("Bridge Too Far", 1),
+    "coldfront": ("Cold Front", 2),
+    "dammage": ("Dammage", 3),
+    "deadlypass": ("Deadly Pass", 4),
+    "harboredge": ("Harbor Edge", 5),
+    "honor": ("Honor", 6),
+    "littlebigeye": ("Little Big Eye", 7),
+    "missilecrisis": ("Missile Crisis", 8),
+    "russianborder": ("Russian Border", 9),
+    "specialop": ("Special Op", 10),
+    "theblackgold": ("The Black Gold", 11),
+    "thenest": ("The Nest", 12)
 }
 RANK_DATA = {
     (0, 25): ("Private", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pv2.png"),

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 06/17/2023
+Date: 06/18/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.2.1"
+    VERSION = "2.3.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
- Adds new `map_stats` database table to hold stats
- Adds `/stats mostplayed` Slash Command Sub-Group
- Adds `/stats mostplayed map` Slash Command
- Added `/stats total` Slash Command Sub-Group
- Added `/stats total playercount` Slash Command
- Small string improvements