### PR TITLE
[v2.4.0] Add Nickname Claiming, Customizing, & Moderating

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 06/30/2023
+Date: 07/01/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.3.1"
+    VERSION = "2.4.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
- Added `/stats nickname` Slash Command Sub-Group
- Added `/stats nickname claim` Slash Command
- Added `/stats nickname color` Slash Command
- Added `/stats nickname assign` admin Slash Command
- Changed `/stats player` to display custom embed color (if set) and Discord member owner (if claimed and user is still a member)