### PR TITLE
[v2.4.3] Bugfix: Prevent Recording Zero-Time Games

### DIFF
--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -318,12 +318,14 @@ class CogPlayerStats(discord.Cog):
                         _server_found = True
                         # Record old data if current time is equal to old time (indicating a game finished),
                         # this is the first detection (times will equal until next game),
-                        # and the server isn't empty.
+                        # the server isn't empty, and game was at least a few sec. long.
                         _old_time = self.time_to_sec(_s_o['time_elapsed'])
                         _new_time = self.time_to_sec(_s_n['time_elapsed'])
                         if (_old_time == _new_time 
                             and _s_o['id'] not in self.game_over_ids
-                            and len(_s_o['players']) > 1):
+                            and len(_s_o['players']) >= self.bot.config['PlayerStats']['MatchMinPlayers']
+                            and _old_time >= self.bot.config['PlayerStats']['MatchMinTimeSec']
+                           ):
                             self.bot.log("[PlayerStats] A server has finished a game:")
                             self.bot.log(f"Server     : {_s_o['server_name']}", time=False)
                             self.bot.log(f"Map        : {CS.MAP_DATA[_s_o['map_name']][0]}", time=False)

--- a/config-example.cfg
+++ b/config-example.cfg
@@ -20,6 +20,8 @@
     },
     "PlayerStats": {
         "PlayerStatsTextChannelID": 012345678901234567,
-        "QueryIntervalSeconds": 10
+        "QueryIntervalSeconds": 10,
+        "MatchMinPlayers": 2,
+        "MatchMinTimeSec": 60
     }
 }

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.4.2"
+    VERSION = "2.4.3"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
- Prevents games from being recorded if they are under a minute long (by default). This also fixes the issue where the API occasionally reports the server frozen at time 00:00, which was falsely counted as a complete match.
- Moved match minimum players and time to config file.