### PR TITLE
[v2.5.3] Fix `map_name` key regression

### DIFF
--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 08/03/2023
+Date: 08/06/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -621,7 +621,7 @@ class CogPlayerStats(discord.Cog):
                 description=f"*Currently, the most played {gamemode} map is...*",
                 color=discord.Colour.dark_blue()
             )
-            _embed.set_image(url=CS.MAP_IMAGES_URL.replace("<map_name>", _dbEntries[0]['mapName']))
+            _embed.set_image(url=CS.MAP_IMAGES_URL.replace("<map_name>", _dbEntries[0]['map_name']))
             _embed.set_footer(text=f"{self.bot.config['API']['HumanURL']}")
             await ctx.respond(embed=_embed)
         else:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/03/2023
+Date: 08/06/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.5.2"
+    VERSION = "2.5.3"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
Small bugfix that fixes `/stats mostplayed map` using the wrong key name for the database data it retrieves. Was introduced by accident in v2.5.0 when the API updated from `map_name` to `mapName`.