### PR TITLE
[v2.5.4] Bugfix: Certain Cog Command Permissions

### DIFF
--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 08/06/2023
+Date: 08/14/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -847,7 +847,6 @@ class CogPlayerStats(discord.Cog):
             await ctx.respond(f':warning: You do not own the nickname "{_escaped_nickname}"\n\nPlease use `/stats nickname claim` to claim it first.', ephemeral=True)
     
     @nickname.command(name = "assign", description="Assigns a Discord member to a nickname. Only admins can do this.")
-    @discord.default_permissions(manage_channels=True) # Only members with Manage Channels permission can use this command.
     async def assign(
         self, 
         ctx,
@@ -867,6 +866,13 @@ class CogPlayerStats(discord.Cog):
         
         Assigns a Discord member to be the owner of a nickname. Only admins can do this.
         """
+        # Only members with Manage Channels permission can use this command.
+        if not ctx.author.guild_permissions.manage_channels:
+            _msg = ":warning: You do not have permission to run this command."
+            _msg += "\n\nPlease try using `/stats nickname claim`, or contact an admin if you need to claim another nickname."
+            await ctx.respond(_msg, ephemeral=True)
+            return
+        
         _dbEntry = self.bot.db.getOne(
             "player_stats", 
             ["id"], 

--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -1,7 +1,7 @@
 """CogServerStatus.py
 
 Handles tasks related to checking server status and info.
-Date: 08/01/2023
+Date: 08/14/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -273,8 +273,6 @@ class CogServerStatus(discord.Cog):
             raise commands.CommandError("There was an error retrieving this data. The statistics API may be down at the moment.")
     
     @server.command(name = "setstatus", description="Manually set the global server status, or set it to automatically update. Only admins can do this.")
-    @discord.default_permissions(manage_channels=True) # Only members with Manage Channels permission can use this command.
-    @commands.cooldown(2, 600, commands.BucketType.guild) # Discord limits channel name changes to twice every 10 min.
     async def setstatus(
         self, 
         ctx, 
@@ -288,12 +286,18 @@ class CogServerStatus(discord.Cog):
         """Slash Command: /server setstatus
         
         Manually sets the global server status, or sets it to automatically update. Only admins can do this.
+        Note: Discord limits channel name changes to twice every 10 min!
         """
+        # Only members with Manage Channels permission can use this command.
+        if not ctx.author.guild_permissions.manage_channels:
+            await ctx.respond(":warning: You do not have permission to run this command.", ephemeral=True)
+            return
+
         self.server_status = status
         status = status.capitalize()
         _msg = f"Global server status set to: {status}"
         _msg += f"\n\n(Please allow up to {self.bot.infl.no('second', UPDATE_INTERVAL*60)} for the status to change)"
-        await ctx.respond(_msg, ephemeral=True)
+        await ctx.respond(_msg)
         self.bot.log(f"[ServerStats] {ctx.author.name} set the global server status to: {status}")
 
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/06/2023
+Date: 08/14/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.5.3"
+    VERSION = "2.5.4"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
Slash command decorators unfortunately cannot be used with specific commands within a slash command group; they can only be applied to the whole group.

- Fixed `/stats nickname assign` being able to be run by anyone (decorator was ignored). Adjusted to manual author permission checking and handling.
- Fixed `/server setstatus` being able to be run by anyone (decorator was ignored). Adjusted to manual author permission checking and handling. Also removed the command cooldown (since it was also ignored) and made the reply non-ephemeral so other admins can see if someone set the status manually.