### PR TITLE
[v2.6.0] Bugfix & Feature Improvements

### DIFF
--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 08/14/2023
+Date: 08/16/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -587,21 +587,21 @@ class CogPlayerStats(discord.Cog):
     """
     mostplayed = stats.create_subgroup("mostplayed", 'Commands related to checking "most played" related stats')
 
-    @mostplayed.command(name = "map", description="See which map has been played the most for a given gamemode")
+    @mostplayed.command(name = "map", description="See which maps have been played the most for a given gamemode")
     @commands.cooldown(1, 180, commands.BucketType.channel)
     async def map(
         self, 
         ctx, 
         gamemode: discord.Option(
             str, 
-            description="Which gamemode to see the most played map for", 
+            description="Which gamemode to see the most played maps for", 
             choices=["Conquest", "Capture the Flag"], 
             required=True
         )
     ):
         """Slash Command: /stats mostplayed map
         
-        Displays which map has been played the most for a given gamemode.
+        Displays which maps have been played the most for a given gamemode.
         """
         _gm_id = "conquest"
         if gamemode == "Capture the Flag":
@@ -612,16 +612,19 @@ class CogPlayerStats(discord.Cog):
             ["map_name"], 
             None, 
             [_gm_id, "DESC"], 
-            [0, 1]
+            [0, 2]
         )
 
         if _dbEntries != None:
+            _desc = f"*Currently, the most played {gamemode} maps are...*\n"
+            for _i, _dbEntry in enumerate(_dbEntries):
+                _desc += f"\n{_i+1}. {CS.MAP_DATA[_dbEntry['map_name']][0]}"
             _embed = discord.Embed(
-                title=f"🗺  Most Played {gamemode} Map",
-                description=f"*Currently, the most played {gamemode} map is...*",
+                title=f"🗺  Most Played *{gamemode}* Maps",
+                description=_desc,
                 color=discord.Colour.dark_blue()
             )
-            _embed.set_image(url=CS.MAP_IMAGES_URL.replace("<map_name>", _dbEntries[0]['map_name']))
+            _embed.set_thumbnail(url=CS.MAP_IMAGES_URL.replace("<map_name>", _dbEntries[0]['map_name']))
             _embed.set_footer(text=f"{self.bot.config['API']['HumanURL']}")
             await ctx.respond(embed=_embed)
         else:

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 08/16/2023
+Date: 08/17/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -906,6 +906,52 @@ class CogPlayerStats(discord.Cog):
             await ctx.respond(f':white_check_mark: {member.name} has successfully been assigned as the owner of nickname "{_escaped_nickname}"!', ephemeral=True)
         else:
             await ctx.respond(f':warning: I have not seen a player by the nickname of "{_escaped_nickname}" play BF2:MC Online since June of 2023.', ephemeral=True)
+    
+    @nickname.command(name = "ownedby", description="See which nicknames are owned by a given Discord member")
+    @commands.cooldown(1, 60, commands.BucketType.channel)
+    async def ownedby(
+        self, 
+        ctx,
+        member: discord.Option(
+            discord.Member, 
+            description="Discord member"
+        )
+    ):
+        """Slash Command: /stats nickname ownedby
+        
+        Displays which nicknames are owned by a given Discord member.
+        """
+        _dbEntries = self.bot.db.getAll(
+            "player_stats", 
+            ["nickname", "first_seen", "score"], 
+            ("dis_uid = %s", [member.id])
+        )
+
+        if _dbEntries != None:
+            _nicknames = "```\n"
+            _rank = "```\n"
+            _first_seen = "```\n"
+            for _dbEntry in _dbEntries:
+                _nicknames += f"{_dbEntry['nickname']}\n"
+                _rank += f"{CS.get_rank_data(_dbEntry['score'])[0]}\n"
+                _first_seen += f"{_dbEntry['first_seen'].strftime('%m/%d/%Y')}\n"
+            _nicknames += "```"
+            _rank += "```"
+            _first_seen += "```"
+            _footer_text = "BF2:MC Online  |  Player Stats"
+            _footer_icon_url = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
+            _embed = discord.Embed(
+                title=f"{member.display_name}'s BF2:MC Online Nicknames",
+                color=member.color
+            )
+            _embed.set_thumbnail(url=member.display_avatar.url)
+            _embed.add_field(name="Nicknames:", value=_nicknames, inline=True)
+            _embed.add_field(name="Rank:", value=_rank, inline=True)
+            _embed.add_field(name="First Seen:", value=_first_seen, inline=True)
+            _embed.set_footer(text=_footer_text, icon_url=_footer_icon_url)
+            await ctx.respond(embed=_embed)
+        else:
+            await ctx.respond(f"{member.display_name} has not claimed or been assigned any BF2:MC Online nicknames yet.", ephemeral=True)
 
 
 def setup(bot):

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -609,22 +609,29 @@ class CogPlayerStats(discord.Cog):
         
         _dbEntries = self.bot.db.getAll(
             "map_stats", 
-            ["map_name"], 
+            ["map_name", _gm_id], 
             None, 
             [_gm_id, "DESC"], 
-            [0, 2]
+            [0, 5]
         )
 
         if _dbEntries != None:
-            _desc = f"*Currently, the most played {gamemode} maps are...*\n"
+            _maps = "```\n"
+            _games = "```\n"
             for _i, _dbEntry in enumerate(_dbEntries):
-                _desc += f"\n{_i+1}. {CS.MAP_DATA[_dbEntry['map_name']][0]}"
+                _maps += f"{_i+1}. {CS.MAP_DATA[_dbEntry['map_name']][0]}\n"
+                _games += f"{self.bot.infl.no('game', _dbEntry[_gm_id]).rjust(11)}\n"
+            _maps += "```"
+            _games += "```"
             _embed = discord.Embed(
                 title=f"🗺  Most Played *{gamemode}* Maps",
-                description=_desc,
+                description=f"*Currently, the most played {gamemode} maps are...*",
                 color=discord.Colour.dark_blue()
             )
-            _embed.set_thumbnail(url=CS.MAP_IMAGES_URL.replace("<map_name>", _dbEntries[0]['map_name']))
+            _embed.add_field(name="Map:", value=_maps, inline=True)
+            _embed.add_field(name="Games Played:", value=_games, inline=True)
+            _embed.add_field(name="Most Played Map:", value="", inline=False)
+            _embed.set_image(url=CS.MAP_IMAGES_URL.replace("<map_name>", _dbEntries[0]['map_name']))
             _embed.set_footer(text=f"{self.bot.config['API']['HumanURL']}")
             await ctx.respond(embed=_embed)
         else:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/14/2023
+Date: 08/16/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.5.4"
+    VERSION = "2.5.5"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/16/2023
+Date: 08/17/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.5.5"
+    VERSION = "2.6.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
- Adds the `/stats nickname ownedby` Slash Command to display which nicknames are owned by a given Discord member.
- `/stats mostplayed map` now displays the top 5 most played maps.
- Fixed a bug where the correct Top Player would not be recorded if they became the Top Player within 10 seconds of the game ending.