### PR TITLE
[v3.0.0] Add PPH, Playtime, Disconnect Detection, Blacklist, Auto-Translate, & Update Pycord

### DIFF
--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -698,6 +698,41 @@ class CogPlayerStats(discord.Cog):
         else:
             await ctx.respond(f':warning: We have not seen a player by the nickname of "{_escaped_nickname}" play BF2:MC Online since June of 2023.', ephemeral=True)
 
+    @stats.command(name = "rankreqs", description="Displays the requirements to reach every rank")
+    @commands.cooldown(1, 180, commands.BucketType.channel)
+    async def rankreqs(
+        self,
+        ctx
+    ):
+        """Slash Command: /stats rankreqs
+        
+        Displays the requirements to reach every rank.
+        """
+        _ranks = "```\n"
+        _score = "```\n"
+        _pph = "```\n"
+        for _i, (_reqs, _rank) in enumerate(CS.RANK_DATA.items()):
+            _ranks += f"{(str(_i+1) + '.').ljust(4)}{_rank[0]}\n"
+            if _rank[0] == "Private":
+                _score += f"{str(0).rjust(6)} pts.\n"
+                _pph += f"{str(0).rjust(5)} PPH\n"
+            else:
+                _score += f"{str(_reqs[0]).rjust(6)} pts.\n"
+                _pph += f"{str(_reqs[1]).rjust(5)} PPH\n"
+        _ranks += "```"
+        _score += "```"
+        _pph += "```"
+        _embed = discord.Embed(
+            title=f":military_medal:  BF2:MC Online | Rank Requirements  :military_medal:",
+            description=f"The following are the requirements to reach each respective rank.\n*Each requirement must be met to reach the rank.*",
+            color=discord.Colour.dark_blue()
+        )
+        _embed.add_field(name="Ranks:", value=_ranks, inline=True)
+        _embed.add_field(name="Score:", value=_score, inline=True)
+        _embed.add_field(name="Points per Hour:", value=_pph, inline=True)
+        _embed.set_footer(text="Source: The original online game (un-modified).\nThe only thing missing are the Medal requirements (which are currently un-trackable).")
+        await ctx.respond(embed=_embed)
+
     @stats.command(name = "dbupdate", description="Temp command to update existing player's playtime and PPH in the DB")
     async def dbupdate(
         self,

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -275,7 +275,7 @@ class CogPlayerStats(discord.Cog):
                     # Calculate the gap for the pph time span
                     _gap_time_span = PPH_TIME_SPAN_HRS - _game_time_hours
                     # Calculate the gap score with the database pph
-                    _gap_score = _summed_stats['pph'] * _gap_time_span
+                    _gap_score = float(_summed_stats['pph']) * _gap_time_span
                     ## Calculate new pph
                     _pph = (_gap_score + _p['score']) / PPH_TIME_SPAN_HRS
                 # Fix minimal and maximum
@@ -375,6 +375,10 @@ class CogPlayerStats(discord.Cog):
                         _stats += f" {self.bot.infl.no('game', _e[stat])} won\n"
                     elif stat == 'top_player':
                         _stats += f" {self.bot.infl.no('game', _e[stat])}\n"
+                    elif stat == 'pph':
+                        _stats += f"{str(int(_e[stat])).rjust(4)} PPH\n"
+                    elif stat == 'playtime':
+                        _stats += f"{str(int(_e[stat]/SECONDS_PER_HOUR)).rjust(5)} hrs.\n"
                     else:
                         _stats += "\n"
                     _rank += 1
@@ -682,6 +686,26 @@ class CogPlayerStats(discord.Cog):
         Displays an unofficial leaderboard of players who were MVP in their games of BF2:MC Online.
         """
         paginator = self.get_paginator_for_stat('top_player')
+        await paginator.respond(ctx.interaction)
+
+    @leaderboard.command(name = "pph", description="See an unofficial leaderboard of players with the most points earned per hour on BF2:MC Online")
+    @commands.cooldown(1, 180, commands.BucketType.channel)
+    async def pph(self, ctx):
+        """Slash Command: /stats leaderboard pph
+        
+        Displays an unofficial leaderboard of players with the most points earned per hour on BF2:MC Online.
+        """
+        paginator = self.get_paginator_for_stat('pph')
+        await paginator.respond(ctx.interaction)
+
+    @leaderboard.command(name = "playtime", description="See an unofficial leaderboard of players with the most hours played on BF2:MC Online")
+    @commands.cooldown(1, 180, commands.BucketType.channel)
+    async def playtime(self, ctx):
+        """Slash Command: /stats leaderboard playtime
+        
+        Displays an unofficial leaderboard of players with the most hours played on BF2:MC Online.
+        """
+        paginator = self.get_paginator_for_stat('playtime')
         await paginator.respond(ctx.interaction)
 
     """Slash Command Sub-Group: /stats mostplayed

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 08/27/2023
+Date: 08/28/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -1136,6 +1136,7 @@ class CogPlayerStats(discord.Cog):
             ["nickname", "first_seen", "score"], 
             ("dis_uid = %s", [member.id])
         )
+        _member_name = self.bot.escape_discord_formatting(member.display_name)
 
         if _dbEntries != None:
             _nicknames = "```\n"
@@ -1151,7 +1152,7 @@ class CogPlayerStats(discord.Cog):
             _footer_text = "BF2:MC Online  |  Player Stats"
             _footer_icon_url = "https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
             _embed = discord.Embed(
-                title=f"{member.display_name}'s BF2:MC Online Nicknames",
+                title=f"{_member_name}'s BF2:MC Online Nicknames",
                 color=member.color
             )
             _embed.set_thumbnail(url=member.display_avatar.url)
@@ -1161,7 +1162,7 @@ class CogPlayerStats(discord.Cog):
             _embed.set_footer(text=_footer_text, icon_url=_footer_icon_url)
             await ctx.respond(embed=_embed)
         else:
-            await ctx.respond(f"{member.display_name} has not claimed or been assigned any BF2:MC Online nicknames yet.", ephemeral=True)
+            await ctx.respond(f"{_member_name} has not claimed or been assigned any BF2:MC Online nicknames yet.", ephemeral=True)
 
     @nickname.command(name = "blacklist", description="Add or remove a nickname from the BF2:MC Online stats blacklist. Only admins can do this.")
     async def blacklist(

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -744,6 +744,7 @@ class CogPlayerStats(discord.Cog):
         """
         if ctx.author.id != 164591752966045696:
             await ctx.respond("You are not authorized to run this command.", ephemeral=True)
+            return
         await ctx.defer(ephemeral=True)
         _dbEntries = self.bot.db.getAll(
             "player_stats", 

--- a/common/CommonStrings.py
+++ b/common/CommonStrings.py
@@ -64,7 +64,9 @@ RANK_DATA = {
 LEADERBOARD_STRINGS = {
     "score": "Score",
     "wins": "Wins",
-    "top_player": "MVP"
+    "top_player": "MVP",
+    "pph": "Points per Hour",
+    "playtime": "Play Time"
 }
 
 

--- a/common/CommonStrings.py
+++ b/common/CommonStrings.py
@@ -39,27 +39,28 @@ MAP_DATA = {
     "theblackgold": ("The Black Gold", 11),
     "thenest": ("The Nest", 12)
 }
+# Rank Data = (Min Score, Min PPH): (Rank Name, Rank Img)
 RANK_DATA = {
-    (0, 25): ("Private", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pv2.png"),
-    (25, 50): ("Private 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pfc.png"),
-    (50, 100): ("Corporal", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpl.png"),
-    (100, 150): ("Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgt.png"),
-    (150, 225): ("Sergeant 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sfc.png"),
-    (225, 360): ("Master Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/msg.png"),
-    (360, 550): ("Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgm.png"),
-    (550, 750): ("Command Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/csm.png"),
-    (750, 1050): ("Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/wo1.png"),
-    (1050, 1500): ("Chief Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cw4.png"),
-    (1500, 2000): ("2nd Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/2lt.png"),
-    (2000, 2800): ("1st Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/1lt.png"),
-    (2800, 4000): ("Captain", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpt.png"),
-    (4000, 5800): ("Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/maj.png"),
-    (5800, 8000): ("Lieutenant Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/ltc.png"),
-    (8000, 12000): ("Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/col.png"),
-    (12000, 16000): ("Brigadier General", "https://www.military-ranks.org/images/ranks/army/large/brigadier-general.png"),
-    (16000, 22000): ("Major General", "https://www.military-ranks.org/images/ranks/army/large/major-general.png"),
-    (22000, 32000): ("Lieutenant General", "https://www.military-ranks.org/images/ranks/army/large/lieutenant-general.png"),
-    (32000, float('inf')): ("5 Star General", "https://www.military-ranks.org/images/ranks/army/large/general-of-the-army.png")
+    (float('-inf'), float('-inf')): ("Private", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pv2.png"),
+    (25, 10): ("Private 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/pfc.png"),
+    (50, 12): ("Corporal", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpl.png"),
+    (100, 15): ("Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgt.png"),
+    (150, 18): ("Sergeant 1st Class", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sfc.png"),
+    (225, 25): ("Master Sergeant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/msg.png"),
+    (360, 28): ("Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/sgm.png"),
+    (550, 30): ("Command Sgt. Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/csm.png"),
+    (750, 32): ("Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/wo1.png"),
+    (1050, 35): ("Chief Warrant Officer", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cw4.png"),
+    (1500, 40): ("2nd Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/2lt.png"),
+    (2000, 42): ("1st Lieutenant", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/1lt.png"),
+    (2800, 50): ("Captain", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/cpt.png"),
+    (4000, 55): ("Major", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/maj.png"),
+    (5800, 60): ("Lieutenant Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/ltc.png"),
+    (8000, 65): ("Colonel", "https://raw.githubusercontent.com/lilkingjr1/persman/master/public/ranks/large/col.png"),
+    (12000, 70): ("Brigadier General", "https://www.military-ranks.org/images/ranks/army/large/brigadier-general.png"),
+    (16000, 80): ("Major General", "https://www.military-ranks.org/images/ranks/army/large/major-general.png"),
+    (22000, 90): ("Lieutenant General", "https://www.military-ranks.org/images/ranks/army/large/lieutenant-general.png"),
+    (32000, 100): ("5 Star General", "https://www.military-ranks.org/images/ranks/army/large/general-of-the-army.png")
 }
 LEADERBOARD_STRINGS = {
     "score": "Score",
@@ -70,8 +71,8 @@ LEADERBOARD_STRINGS = {
 }
 
 
-def get_rank_data(score: int) -> tuple:
-    """Returns rank name and image as a tuple given a score"""
-    for score_range, rank_data in RANK_DATA.items():
-        if score_range[0] <= score < score_range[1]:
+def get_rank_data(score: int, pph: int) -> tuple:
+    """Returns rank name and image as a tuple given a score and PPH"""
+    for (min_score, min_pph), rank_data in reversed(RANK_DATA.items()):
+        if score >= min_score and pph >= min_pph:
             return rank_data

--- a/config-example.cfg
+++ b/config-example.cfg
@@ -19,7 +19,7 @@
     },
     "PlayerStats": {
         "PlayerStatsTextChannelID": 012345678901234567,
-        "QueryIntervalSeconds": 10,
+        "QueryIntervalSeconds": 15,
         "MatchMinPlayers": 2,
         "MatchMinTimeSec": 60,
         "DelStatsSavedMsgSec": 60,

--- a/config-example.cfg
+++ b/config-example.cfg
@@ -21,7 +21,9 @@
         "PlayerStatsTextChannelID": 012345678901234567,
         "QueryIntervalSeconds": 10,
         "MatchMinPlayers": 2,
-        "MatchMinTimeSec": 60
+        "MatchMinTimeSec": 60,
+        "DelStatsSavedMsgSec": 60,
+        "PphTimeSpanHrs": 5
     },
     "Emoji": {
         "Ribbons": {

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/17/2023
+Date: 08/21/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -13,7 +13,7 @@ from discord.ext import commands
 from src import BackstabBot
 
 def main():
-    VERSION = "2.6.1"
+    VERSION = "2.7.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/21/2023
+Date: 08/28/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -146,7 +146,7 @@ def main():
         
         Displays information about the Backstab Bot.
         """
-        _description = ("Backstab is a custom Discord bot, written for the Battlefield 2: Modern Combat Veterans community, "
+        _description = ("BackStab is a custom Discord bot, written for the Battlefield 2: Modern Combat Veterans community, "
                         "that can provide server status information and other useful related information.")
         _embed = discord.Embed(
             title="About:",
@@ -154,7 +154,7 @@ def main():
             color=discord.Colour.blue()
         )
         _embed.set_author(
-            name="Backstab", 
+            name="BackStab Bot", 
             icon_url="https://raw.githubusercontent.com/lilkingjr1/backstab-discord-bot/main/assets/icon.png"
         )
         _embed.set_thumbnail(url="https://cdn.discordapp.com/icons/502923049541304320/4d8d584de5d9baec281d4861c6b11781.webp?size=4096")

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "2.7.0"
+    VERSION = "3.0.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-cord
+py-cord-dev==2.5.0rc5
 requests
 inflect
 git+https://github.com/lilkingjr1/simplemysql

--- a/src/bot.py
+++ b/src/bot.py
@@ -159,7 +159,8 @@ class BackstabBot(discord.Bot):
 
         # Check if the request was successful (status code 200 indicates success)
         if _DEBUG:
-            self.cur_query_data = _DEBUG
+            self.reload_config()
+            self.cur_query_data = self.config['DEBUG']
             self.log("Success (DEBUG).", time=False, file=False)
         elif _response.status_code == 200:
             self.log("Success.", time=False, file=False)

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,7 +1,7 @@
 """bot.py
 
 A subclass of `discord.Bot` that adds ease-of-use instance variables and functions (e.g. database object).
-Date: 08/02/2023
+Date: 08/27/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -44,6 +44,7 @@ class BackstabBot(discord.Bot):
     @staticmethod
     def escape_discord_formatting(text: str) -> str:
         """Return a string that escapes any of Discord's formatting special characters for the given string"""
+        if text == None: return "None"
         formatting_chars = ['*', '_', '`', '~', '|']
         escaped_chars = ['\\*', '\\_', '\\`', '\\~', '\\|']
         for char, escaped_char in zip(formatting_chars, escaped_chars):


### PR DESCRIPTION
### Player Stats:
- Added PPH stat tracking
  - Added to `/stats player` displayed data.
  - Adjusted `/stats player` rank calculation to now consider the PPH requirement.
  - Adjusted `/stats nickname ownedby` rank calculation to now consider the PPH requirement.
  - PPH timespan can be adjusted in the config.
  - Added `/stats leaderboard pph` Slash Command.
- Added Playtime stat tracking
  - Added to `/stats player` displayed data.
  - Added `/stats leaderboard playtime` Slash Command.
- Added Player Disconnect Detection
  - Players who leave a game before it ends will now have their stats for that game still recorded when the game ends.
  - All stats will be recorded (including win/loss, team played, etc.), except for what gamemode they played (which contributes to total games calculation) and Top Player status.
- Added idle player skipping for recording stats
  - Players with 0 score and 0 deaths will not have their stats recorded.
- Added Nickname Blacklist
  - Added new `player_blacklist` database table.
  - Added `/stats nickname blacklist` Slash Command to add or remove nicknames from the stats blacklist.
  - Added checks to the blacklist for Top Player calculation and stats recording.
- Added `/stats rankreqs` Slash Command to display a reference for the different rank requirements.
- Moved variable to config that defined how many seconds the "Stats Saved" message should remain in chat after posting.
- Added `/stats dbupdate` Slash Command for one-time use after release to update existing player's playtime and PPH in the DB.

### Auto Language Translation:
- Can be enabled or disabled in config.
- Text Channel(s) to be monitored for automatic language translation can be set in the config.
- Primary language to translate to can be set in the config.
- Languages to be detected and auto-translated can be set in the config (`FromLangs`).
- Primary language speakers can reply to the auto-translate embed messages to reply back to the original translated author in their native language.

### Updated Pycord:
- Updated `py-cord` to use the new temporary stable dev release `py-cord-dev==2.5.0rc5`.
  - This is primarily to fix `member.display_name`.

### Bugfixes:
- Added safeguard to `escape_discord_formatting()` for passed "None" strings.
- Updated `config-example.cfg` to have correct `QueryIntervalSeconds`.
- Fixed `/stats nickname claim` possibly displaying an un-escaped nickname.
- Query API DEBUG mode now refreshes the config automatically every query.