### PR TITLE
[v3.1.0] Add Server Status Blacklist

### DIFF
--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 08/28/2023
+Date: 09/01/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -412,7 +412,7 @@ class CogPlayerStats(discord.Cog):
                     _rank_str = f"#{_rank}"
                     _nicknames += f"{_rank_str.ljust(3)} | {_e['nickname']}\n"
                     if stat == 'score':
-                        _stats += f"{str(_e[stat]).rjust(5)} pts.\n"
+                        _stats += f"{str(_e[stat]).rjust(6)} pts.\n"
                     elif stat == 'wins':
                         _stats += f" {self.bot.infl.no('game', _e[stat])} won\n"
                     elif stat == 'top_player':

--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -1,7 +1,7 @@
 """CogServerStatus.py
 
 Handles tasks related to checking server status and info.
-Date: 08/14/2023
+Date: 09/01/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -53,6 +53,7 @@ class CogServerStatus(discord.Cog):
         """Get Server Statistic Embeds
         
         Returns a list of Discord Embeds that each display each server's current statistics.
+        Excludes Server IDs in the config blacklist.
         """
         # Check for missing query data
         if self.bot.cur_query_data == None:
@@ -90,6 +91,10 @@ class CogServerStatus(discord.Cog):
         # Default - Build server stat embeds
         _embeds = []
         for s in self.bot.cur_query_data['servers']:
+            # Skip blacklisted Server IDs
+            if s['id'] in self.bot.config['ServerStatus']['Blacklist']:
+                continue
+
             # Get total player count
             _player_count = s['playersCount']
 

--- a/config-example.cfg
+++ b/config-example.cfg
@@ -15,7 +15,11 @@
     "ServerStatus": {
         "StatusVoiceChannelID": 012345678901234567,
         "ServerStatsTextChannelID": 012345678901234567,
-        "AnnouncementTextChannelID": 012345678901234567
+        "AnnouncementTextChannelID": 012345678901234567,
+        "Blacklist": [
+            "804ebcb687b05c08e070cf2b28445a8b44840463bbaa20bbd4ce17f8b1dbc47f",
+            "4d872b9c10b3034db4f33975a67932bfa50e00425a31a9715dc60914bbcbc87b"
+        ]
     },
     "PlayerStats": {
         "PlayerStatsTextChannelID": 012345678901234567,

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/28/2023
+Date: 09/01/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
- Adds Server Status Blacklist to config that can consist of Server IDs to not display in the server status text channel.
- Adjusted top scores display right by 1 character to look better.