### PR TITLE
[v3.1.2] Bugfix: First status post not saved to memory

### DIFF
--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -1,7 +1,7 @@
 """CogServerStatus.py
 
 Handles tasks related to checking server status and info.
-Date: 09/01/2023
+Date: 09/10/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -194,9 +194,11 @@ class CogServerStatus(discord.Cog):
         ]
         await self.bot.check_channel_ids_for_cfg_key('ServerStatus', _cfg_sub_keys)
 
+        # Get handle for server stats text channel
+        _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
+
         # Get status message (if it exists) from message history (if we haven't already)
         if self.status_msg == None:
-            _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
             async for _m in _text_channel.history(limit=3):
                 # Check if the message was sent by the user
                 if _m.author == self.bot.user:
@@ -208,7 +210,6 @@ class CogServerStatus(discord.Cog):
             self.StatusLoop.start()
             self.bot.log(f"[ServerStatus] StatusLoop started ({UPDATE_INTERVAL} min. interval).")
             # Set channel description if it is not correct
-            _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
             _topic = f"Live server statistics (Updated every {self.bot.infl.no('second', round(UPDATE_INTERVAL*60))})"
             if _text_channel.topic != _topic:
                 await _text_channel.edit(topic=_topic)
@@ -248,15 +249,17 @@ class CogServerStatus(discord.Cog):
             await self.set_status_channel_name("unknown")
 
         ## Update stats channel post
+        # Post already exists
         if self.status_msg != None:
             try:
                 await self.status_msg.edit(f"## Total Players Online: {self.total_online}", embeds=self.get_server_stat_embeds())
             except Exception as e:
                 self.bot.log("[WARNING] Unable to edit server stats message. Is the Discord API down?")
                 self.bot.log(f"Exception:\n{e}", time=False)
+        # First post needs to be made
         else:
             _text_channel = self.bot.get_channel(self.bot.config['ServerStatus']['ServerStatsTextChannelID'])
-            await _text_channel.send(f"## Total Players Online: {self.total_online}", embeds=self.get_server_stat_embeds())
+            self.status_msg = await _text_channel.send(f"## Total Players Online: {self.total_online}", embeds=self.get_server_stat_embeds())
 
 
     """Slash Command Group: /server

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 09/04/2023
+Date: 09/10/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "3.1.1"
+    VERSION = "3.1.2"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",


### PR DESCRIPTION
- In the case where there is no history of server status posts in the server status text channel, a new post would be made, but its handle would not be committed to memory. This would lead to the bot continually making "first" posts.
- Small refactor to try to reduce Discord API calls for the channel handle.