### PR TITLE
[v3.2.0] Stats Integrity Update

### DIFF
--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -494,19 +494,25 @@ class CogPlayerStats(discord.Cog):
                             and _old_time >= self.bot.config['PlayerStats']['MatchMinTimeSec']
                            ):
                             self.bot.log("[PlayerStats] A server has finished a game:")
-                            self.bot.log(f"Server     : {_s_o['serverName']}", time=False)
-                            self.bot.log(f"Map        : {CS.MAP_DATA[_s_o['mapName']][0]}", time=False)
-                            #self.bot.log(f"Orig. Time : {_s_o['timeElapsed']} ({_old_time} sec.)", time=False, file=False) # DEBUGGING
-                            #self.bot.log(f"New Time   : {_s_n['timeElapsed']} ({_new_time} sec.)", time=False, file=False)
+                            self.bot.log(f"Server      : {_s_o['serverName']}", time=False)
                             # Record round stats and get top player nickname
                             _top_player = await self.record_round_stats(_s_o)
-                            self.bot.log(f"Top Player : {_top_player}", time=False)
+                            self.bot.log(f"Gamemode    : {CS.GM_STRINGS[_s_o['gameType']]}", time=False)
+                            self.bot.log(f"Final Score : {_s_o['teams'][0]['score']} / {_s_o['teams'][1]['score']}", time=False)
+                            self.bot.log(f"Map         : {CS.MAP_DATA[_s_o['mapName']][0]}", time=False)
+                            self.bot.log(f"Top Player  : {_top_player}", time=False)
+                            #self.bot.log(f"Orig. Time : {_s_o['timeElapsed']} ({_old_time} sec.)", time=False, file=False) # DEBUGGING
+                            #self.bot.log(f"New Time   : {_s_n['timeElapsed']} ({_new_time} sec.)", time=False, file=False)
                             await self.record_map_stats(_s_o)
                             # Send temp message to player stats channel that stats were recorded
                             _text_channel = self.bot.get_channel(self.bot.config['PlayerStats']['PlayerStatsTextChannelID'])
+                            _desc_text = f"Gamemode: *{CS.GM_STRINGS[_s_o['gameType']]}*"
+                            _desc_text += f"\nMap: *{CS.MAP_DATA[_s_o['mapName']][0]}*"
+                            _desc_text += f"\nFinal Score: *{_s_o['teams'][0]['score']} / {_s_o['teams'][1]['score']}*"
+                            _desc_text += f"\nMVP: *{self.bot.escape_discord_formatting(_top_player)}*"
                             _embed = discord.Embed(
                                 title="Player Stats Saved!",
-                                description=f"Map Played: *{CS.MAP_DATA[_s_o['mapName']][0]}*\nTop Player: *{self.bot.escape_discord_formatting(_top_player)}*",
+                                description=_desc_text,
                                 color=discord.Colour.green()
                             )
                             _embed.set_author(

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 09/04/2023
+Date: 09/09/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -761,8 +761,11 @@ class CogPlayerStats(discord.Cog):
                 _pph = 50
             else:
                 _pph = _dbEntry['score'] / _playtime_hrs
-            _pph = round(_pph, 2)
-            print(_pph)
+            # Fix minimal and maximum
+            if _pph < 0:
+                _pph = 1
+            elif _pph > 200:
+                _pph = 200
             self.bot.db.update(
                 "player_stats", 
                 {

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 09/01/2023
+Date: 09/04/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -1214,7 +1214,7 @@ class CogPlayerStats(discord.Cog):
                 _msg = f':white_check_mark: "{_escaped_nickname}" has been added to the stats blacklist.'
                 _msg += "\n\nThis nickname will not accumulate stats when games end as long as they are on this list."
                 _msg += "\nExisting stats for this nickname will not be adjusted or removed."
-                await ctx.respond(_msg, ephemeral=True)
+                await ctx.respond(_msg)
             else:
                 await ctx.respond(f'"{_escaped_nickname}" is already blacklisted.', ephemeral=True)
         # Remove nickname

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -761,6 +761,8 @@ class CogPlayerStats(discord.Cog):
                 _pph = 50
             else:
                 _pph = _dbEntry['score'] / _playtime_hrs
+            _pph = round(_pph, 2)
+            print(_pph)
             self.bot.db.update(
                 "player_stats", 
                 {

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -733,50 +733,6 @@ class CogPlayerStats(discord.Cog):
         _embed.set_footer(text="Source: The original online game (un-modified).\nThe only thing missing are the Medal requirements (which are currently un-trackable).")
         await ctx.respond(embed=_embed)
 
-    @stats.command(name = "dbupdate", description="Temp command to update existing player's playtime and PPH in the DB")
-    async def dbupdate(
-        self,
-        ctx
-    ):
-        """Slash Command: /stats dbupdate
-        # DEBUGGING
-        Temp command to update existing player's playtime and PPH in the DB.
-        """
-        if ctx.author.id != 164591752966045696:
-            await ctx.respond("You are not authorized to run this command.", ephemeral=True)
-            return
-        await ctx.defer(ephemeral=True)
-        _dbEntries = self.bot.db.getAll(
-            "player_stats", 
-            ["id", "pid", "score", "cq_games", "cf_games"], 
-            None
-        )
-        _count = 0
-        for _dbEntry in _dbEntries:
-            _playtime_sec = (_dbEntry['cq_games'] * 755) + (_dbEntry['cf_games'] * 720)
-            _playtime_hrs = _playtime_sec / SECONDS_PER_HOUR
-            if _playtime_hrs <= 1.0:
-                _pph = _dbEntry['score']
-            elif _dbEntry['pid'] == None and _dbEntry['score'] / _playtime_hrs > 50:
-                _pph = 50
-            else:
-                _pph = _dbEntry['score'] / _playtime_hrs
-            # Fix minimal and maximum
-            if _pph < 0:
-                _pph = 1
-            elif _pph > 200:
-                _pph = 200
-            self.bot.db.update(
-                "player_stats", 
-                {
-                    "pph": _pph, 
-                    "playtime": _playtime_sec
-                }, 
-                [f"id={_dbEntry['id']}"]
-            )
-            _count += 1
-        await ctx.respond(f"{_count} DB entries updated", ephemeral=True)
-
     """Slash Command Sub-Group: /stats leaderboard
     
     A sub-group of commands related to checking the leaderboard for various player stats.

--- a/cogs/CogPlayerStats.py
+++ b/cogs/CogPlayerStats.py
@@ -1,7 +1,7 @@
 """CogPlayerStats.py
 
 Handles tasks related to checking player stats and info.
-Date: 08/28/2023
+Date: 09/01/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -412,7 +412,7 @@ class CogPlayerStats(discord.Cog):
                     _rank_str = f"#{_rank}"
                     _nicknames += f"{_rank_str.ljust(3)} | {_e['nickname']}\n"
                     if stat == 'score':
-                        _stats += f"{str(_e[stat]).rjust(5)} pts.\n"
+                        _stats += f"{str(_e[stat]).rjust(6)} pts.\n"
                     elif stat == 'wins':
                         _stats += f" {self.bot.infl.no('game', _e[stat])} won\n"
                     elif stat == 'top_player':

--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -1,7 +1,7 @@
 """CogServerStatus.py
 
 Handles tasks related to checking server status and info.
-Date: 08/14/2023
+Date: 09/01/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -53,6 +53,7 @@ class CogServerStatus(discord.Cog):
         """Get Server Statistic Embeds
         
         Returns a list of Discord Embeds that each display each server's current statistics.
+        Excludes Server IDs in the config blacklist.
         """
         # Check for missing query data
         if self.bot.cur_query_data == None:
@@ -90,6 +91,10 @@ class CogServerStatus(discord.Cog):
         # Default - Build server stat embeds
         _embeds = []
         for s in self.bot.cur_query_data['servers']:
+            # Skip blacklisted Server IDs
+            if s['id'] in self.bot.config['ServerStatus']['Blacklist']:
+                continue
+
             # Get total player count
             _player_count = s['playersCount']
 

--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -1,7 +1,7 @@
 """CogServerStatus.py
 
 Handles tasks related to checking server status and info.
-Date: 09/01/2023
+Date: 09/09/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -221,10 +221,12 @@ class CogServerStatus(discord.Cog):
         Runs every interval period, references bot's latest query data, 
         updates status voice channel, and updates info text channel.
         """
-        ## Calculate total players online
+        ## Calculate total players online (excluding blacklisted servers)
         _total_online = 0
         if self.bot.cur_query_data != None:
-            _total_online = self.bot.cur_query_data['playersCount']
+            for _s in self.bot.cur_query_data['servers']:
+                if _s['id'] not in self.bot.config['ServerStatus']['Blacklist']:
+                    _total_online += _s['playersCount']
         
         ## Update bot's activity if total players has changed
         if _total_online != self.total_online:

--- a/cogs/CogServerStatus.py
+++ b/cogs/CogServerStatus.py
@@ -68,6 +68,9 @@ class CogServerStatus(discord.Cog):
             # Skip blacklisted Server IDs
             if _s['id'] in self.bot.config['ServerStatus']['Blacklist']:
                 continue
+            # Skip broken API entry
+            if len(_s['teams']) < 2:
+                continue
             _embeds.append(self.bot.get_server_status_embed(_s))
         
         return _embeds

--- a/config-example.cfg
+++ b/config-example.cfg
@@ -15,7 +15,11 @@
     "ServerStatus": {
         "StatusVoiceChannelID": 012345678901234567,
         "ServerStatsTextChannelID": 012345678901234567,
-        "AnnouncementTextChannelID": 012345678901234567
+        "AnnouncementTextChannelID": 012345678901234567,
+        "Blacklist": [
+            "804ebcb687b05c08e070cf2b28445a8b44840463bbaa20bbd4ce17f8b1dbc47f",
+            "4d872b9c10b3034db4f33975a67932bfa50e00425a31a9715dc60914bbcbc87b"
+        ]
     },
     "PlayerStats": {
         "PlayerStatsTextChannelID": 012345678901234567,

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 09/04/2023
+Date: 09/09/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "3.1.1"
+    VERSION = "3.2.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 09/01/2023
+Date: 09/04/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "3.1.0"
+    VERSION = "3.1.1"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """main.py
 
 Main file to start Backstab
-Date: 08/28/2023
+Date: 09/01/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -19,7 +19,7 @@ from src import BackstabBot
 import common.CommonStrings as CS
 
 def main():
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
     AUTHORS = "Red-Thirten"
     COGS_LIST = [
         "CogPlayerStats",

--- a/src/bot.py
+++ b/src/bot.py
@@ -21,7 +21,6 @@ LOG_FILE = "BackstabBot.log"
 
 class BackstabBot(discord.Bot):
     @staticmethod
-    #get_datetime_str
     def log(msg: str, time: bool = True, file: bool = True, end: str = '\n'):
         """Custom Logging
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,7 +1,7 @@
 """bot.py
 
 A subclass of `discord.Bot` that adds ease-of-use instance variables and functions (e.g. database object).
-Date: 08/27/2023
+Date: 09/10/2023
 Authors: David Wolfe (Red-Thirten)
 Licensed under GNU GPLv3 - See LICENSE for more details.
 """
@@ -100,6 +100,14 @@ class BackstabBot(discord.Bot):
         Called when the bot successfully connects to the API and becomes online.
         Excessive API calls in this function should be avoided.
         """
+        # Print invite link and close bot if it is not already in a guild
+        if len(self.guilds) < 1:
+            print("==========================================================================")
+            print("Use following link to invite bot to guild, and then restart the bot:")
+            print(f"https://discord.com/api/oauth2/authorize?client_id={self.application_id}&permissions=85072&scope=bot%20applications.commands")
+            print("==========================================================================")
+            await self.close()
+        
         # Check that guild_id is valid
         _guild = self.get_guild(self.config['GuildID'])
         if _guild == None:


### PR DESCRIPTION
- Adds Stats Integrity Warning System that checks final round data of a server for any suspicious stats and reports them as a warning to the configured text channel.
- Add PPH Drain system.
- Add configurable minimum players in game to earn MVP.
- Added Gamemode and Final Score info to the "Player Stats Saved" message.
- Add `last_seen` timestamp to database.
- Add bot invite link print at bootup, if needed.
- Add error handling for broken API server entries
- Servers are now marked as being in a post game state quicker.
- Fix blacklisted servers getting counted for players.
- Fix blacklist remove message being ephemeral.